### PR TITLE
Refactor path parsing - remove splats in favour of slash accepting path parameters 

### DIFF
--- a/avaje-jex-grizzly/src/main/java/io/avaje/jex/grizzly/GrizzlyContext.java
+++ b/avaje-jex-grizzly/src/main/java/io/avaje/jex/grizzly/GrizzlyContext.java
@@ -188,16 +188,6 @@ class GrizzlyContext implements Context, SpiContext {
   }
 
   @Override
-  public String splat(int position) {
-    return params.splats.get(position);
-  }
-
-  @Override
-  public List<String> splats() {
-    return params.splats;
-  }
-
-  @Override
   public Map<String, String> pathParamMap() {
     return params.pathParams;
   }

--- a/avaje-jex-jdk/src/main/java/io/avaje/jex/jdk/JdkContext.java
+++ b/avaje-jex-jdk/src/main/java/io/avaje/jex/jdk/JdkContext.java
@@ -215,16 +215,6 @@ class JdkContext implements Context, SpiContext {
   }
 
   @Override
-  public String splat(int position) {
-    return params.splats.get(position);
-  }
-
-  @Override
-  public List<String> splats() {
-    return params.splats;
-  }
-
-  @Override
   public Map<String, String> pathParamMap() {
     return params.pathParams;
   }

--- a/avaje-jex-jetty/src/main/java/io/avaje/jex/jetty/JexHttpContext.java
+++ b/avaje-jex-jetty/src/main/java/io/avaje/jex/jetty/JexHttpContext.java
@@ -29,7 +29,6 @@ class JexHttpContext implements SpiContext {
   protected final HttpServletRequest req;
   private final HttpServletResponse res;
   private final Map<String, String> pathParams;
-  private final List<String> splats;
   private final String matchedPath;
   private String characterEncoding;
   private Routing.Type mode;
@@ -41,7 +40,6 @@ class JexHttpContext implements SpiContext {
     this.res = res;
     this.matchedPath = matchedPath;
     this.pathParams = Collections.emptyMap();
-    this.splats = null;
   }
 
   JexHttpContext(ServiceManager mgr, HttpServletRequest req, HttpServletResponse res, String matchedPath, SpiRoutes.Params params) {
@@ -50,7 +48,6 @@ class JexHttpContext implements SpiContext {
     this.res = res;
     this.matchedPath = matchedPath;
     this.pathParams = params.pathParams;
-    this.splats = params.splats;
   }
 
   @Override
@@ -225,16 +222,6 @@ class JexHttpContext implements SpiContext {
   @Override
   public long contentLength() {
     return req.getContentLengthLong();
-  }
-
-  @Override
-  public String splat(int position) {
-    return splats == null ? null : splats.get(position);
-  }
-
-  @Override
-  public List<String> splats() {
-    return splats == null ? Collections.emptyList() : splats;
   }
 
   @Override

--- a/avaje-jex-jetty/src/test/java/io/avaje/jex/base/RouteSplatTest.java
+++ b/avaje-jex-jetty/src/test/java/io/avaje/jex/base/RouteSplatTest.java
@@ -16,9 +16,9 @@ class RouteSplatTest {
     var app = Jex.create()
       .routing(routing -> routing
         .get("/{id}/one", ctx -> ctx.text("id:" + ctx.pathParam("id")))
-        .get("/{id}/one2", ctx -> ctx.text("id:" + ctx.pathParam("id") + "-" + ctx.splats() + "-" + ctx.splat(0) + "-" + ctx.splat(99)))
-        .get("/*/one", ctx -> ctx.text("splat:" + ctx.splat(0)))
-        .get("/*/two/*", ctx -> ctx.text("splats:" + ctx.splats()))
+        .get("/{id}/one2", ctx -> ctx.text("id:" + ctx.pathParam("id")))
+        .get("/<a>/one", ctx -> ctx.text("s1:" + ctx.pathParam("a")))
+        .get("/<a>/two/<b>", ctx -> ctx.text("s2:" + ctx.pathParam("a") + "|" + ctx.pathParam("b")))
       );
     return TestPair.create(app);
   }
@@ -36,7 +36,7 @@ class RouteSplatTest {
     // HttpResponse<String> res = pair.request().path(path).get().asString();
 
     HttpResponse<String> res = pair.request().path("java/kotlin/two/x/y").GET().asString();
-    assertThat(res.body()).isEqualTo("splats:[java/kotlin, x/y]");
+    assertThat(res.body()).isEqualTo("s2:java/kotlin|x/y");
     assertThat(res.statusCode()).isEqualTo(200);
   }
 
@@ -52,7 +52,7 @@ class RouteSplatTest {
     HttpResponse<String> res = pair.request().path("42/foo/one").GET().asString();
 
     assertThat(res.statusCode()).isEqualTo(200);
-    assertThat(res.body()).isEqualTo("splat:42/foo");
+    assertThat(res.body()).isEqualTo("s1:42/foo");
   }
 
   @Test
@@ -60,7 +60,7 @@ class RouteSplatTest {
     HttpResponse<String> res = pair.request().path("a/b/c/two/x/y").GET().asString();
 
     assertThat(res.statusCode()).isEqualTo(200);
-    assertThat(res.body()).isEqualTo("splats:[a/b/c, x/y]");
+    assertThat(res.body()).isEqualTo("s2:a/b/c|x/y");
   }
 
   @Test
@@ -68,6 +68,6 @@ class RouteSplatTest {
     HttpResponse<String> res = pair.request().path("42/one2").GET().asString();
 
     assertThat(res.statusCode()).isEqualTo(200);
-    assertThat(res.body()).isEqualTo("id:42-[]-null-null");
+    assertThat(res.body()).isEqualTo("id:42");
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Context.java
@@ -123,18 +123,6 @@ public interface Context {
   Context contentType(String contentType);
 
   /**
-   * Return the splat path value for the given position.
-   *
-   * @param position the index postion of the splat starting with 0.
-   */
-  String splat(int position);
-
-  /**
-   * Return all the splat values.
-   */
-  List<String> splats();
-
-  /**
    * Return all the path parameters as a map.
    */
   Map<String, String> pathParamMap();

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/FilterEntry.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/FilterEntry.java
@@ -59,7 +59,7 @@ class FilterEntry implements SpiRoutes.Entry {
   }
 
   @Override
-  public int getSegmentCount() {
+  public int segmentCount() {
     throw new IllegalStateException("not allowed");
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/FilterEntry.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/FilterEntry.java
@@ -5,8 +5,6 @@ import io.avaje.jex.Handler;
 import io.avaje.jex.Routing;
 import io.avaje.jex.spi.SpiRoutes;
 
-import java.util.Map;
-
 /**
  * Filter with special matchAll.
  */
@@ -66,7 +64,7 @@ class FilterEntry implements SpiRoutes.Entry {
   }
 
   @Override
-  public boolean includesWildcard() {
-    return pathParser != null && pathParser.includesWildcard();
+  public boolean multiSlash() {
+    return pathParser != null && pathParser.multiSlash();
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
@@ -12,8 +12,6 @@ import java.util.regex.Pattern;
 
 class PathParser {
 
-  private static final PathSegment.Wildcard WILDCARD = new PathSegment.Wildcard();
-
   private final String rawPath;
   private final List<String> paramNames = new ArrayList<>();
   private final Pattern matchRegex;
@@ -76,7 +74,7 @@ class PathParser {
   private PathSegment parseSegment(String seg) {
     if (seg.equals("*")) {
       includesWildcard = true;
-      return WILDCARD;
+      return PathSegment.WILDCARD;
     }
     return new PathSegmentParser(seg, rawPath).parse();
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
@@ -74,14 +74,11 @@ class PathParser {
   }
 
   private PathSegment parseSegment(String seg) {
-    if (seg.startsWith("{")) {
-      return new PathSegment.Parameter(seg.substring(1, seg.length() - 1));
-    }
     if (seg.equals("*")) {
       includesWildcard = true;
       return WILDCARD;
     }
-    return new PathSegment.Literal(seg);
+    return new PathSegmentParser(seg, rawPath).parse();
   }
 
   /**

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
@@ -16,7 +16,7 @@ class PathParser {
   private final List<String> paramNames = new ArrayList<>();
   private final Pattern matchRegex;
   private final Pattern pathParamRegex;
-  private final boolean includesWildcard;
+  private final boolean multiSlash;
   private int segmentCount;
 
   PathParser(String path, boolean ignoreTrailingSlashes) {
@@ -36,7 +36,7 @@ class PathParser {
 
     this.matchRegex = regBuilder.matchRegex();
     this.pathParamRegex = regBuilder.extractRegex();
-    this.includesWildcard = regBuilder.includesWildcard();
+    this.multiSlash = regBuilder.multiSlash();
   }
 
   public boolean matches(String url) {
@@ -88,9 +88,9 @@ class PathParser {
   }
 
   /**
-   * Return true if one of the segments is the wildcard match.
+   * Return true if one of the segments is wildcard or slash accepting.
    */
-  public boolean includesWildcard() {
-    return includesWildcard;
+  public boolean multiSlash() {
+    return multiSlash;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegment.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegment.java
@@ -10,7 +10,7 @@ abstract class PathSegment {
 
   abstract void addParamName(List<String> paramNames);
 
-  boolean includesWildcard() {
+  boolean multiSlash() {
     return false;
   }
 
@@ -26,7 +26,7 @@ abstract class PathSegment {
     }
 
     @Override
-    boolean includesWildcard() {
+    boolean multiSlash() {
       return true;
     }
   }
@@ -65,9 +65,9 @@ abstract class PathSegment {
     }
 
     @Override
-    boolean includesWildcard() {
+    boolean multiSlash() {
       for (PathSegment segment : segments) {
-        if (segment.includesWildcard()) {
+        if (segment.multiSlash()) {
           return true;
         }
       }
@@ -110,7 +110,7 @@ abstract class PathSegment {
   static class Wildcard extends PathSegment {
 
     @Override
-    boolean includesWildcard() {
+    boolean multiSlash() {
       return true;
     }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegment.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegment.java
@@ -2,7 +2,11 @@ package io.avaje.jex.routes;
 
 import java.util.List;
 
+import static java.util.stream.Collectors.joining;
+
 abstract class PathSegment {
+
+  static final PathSegment WILDCARD = new PathSegment.Wildcard();
 
   abstract String asRegexString(boolean extract);
 
@@ -42,6 +46,29 @@ abstract class PathSegment {
     @Override
     public void addParamName(List<String> paramNames) {
       paramNames.add(name);
+    }
+  }
+
+  static class Multi extends PathSegment {
+
+    private final List<PathSegment> segments;
+
+    Multi(List<PathSegment> segments) {
+      this.segments = segments;
+    }
+
+    @Override
+    String asRegexString(boolean extract) {
+      return segments.stream()
+        .map(pathSegment -> pathSegment.asRegexString(extract))
+        .collect(joining());
+    }
+
+    @Override
+    void addParamName(List<String> paramNames) {
+      for (PathSegment segment : segments) {
+        segment.addParamName(paramNames);
+      }
     }
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegment.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegment.java
@@ -8,15 +8,27 @@ abstract class PathSegment {
 
   abstract void addParamName(List<String> paramNames);
 
-  static class Parameter extends PathSegment {
+  static class SlashIgnoringParameter extends Parameter {
+    SlashIgnoringParameter(String param) {
+      super(param, "[^/]+?"); // Accepting everything except slash;);
+    }
+  }
+
+  static class SlashAcceptingParameter extends Parameter {
+    SlashAcceptingParameter(String param) {
+      super(param, ".+?"); // Accept everything
+    }
+  }
+
+  private static class Parameter extends PathSegment {
     private final String name;
     private final String regex;
 
-    Parameter(String param) {
+    Parameter(String param, String acceptPattern) {
       final String[] split = param.split(":", 2);
       this.name = split[0];
       if (split.length == 1) {
-        this.regex = "[^/]+?"; // Accepting everything except slash;
+        this.regex = acceptPattern;
       } else {
         this.regex = split[1];
       }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
@@ -1,0 +1,48 @@
+package io.avaje.jex.routes;
+
+class PathSegmentParser {
+  private static final String[] ADJACENT_VIOLATIONS = {"*{", "*<", "}*", ">*"};
+
+  private final String seg;
+  private final String rawPath;
+
+  PathSegmentParser(String seg, String rawPath) {
+    this.seg = seg;
+    this.rawPath = rawPath;
+  }
+
+  PathSegment parse() {
+    checkAdjacentViolations();
+    if (matchOnlyStartEnd('{', '}')) {
+        return new PathSegment.SlashIgnoringParameter(seg.substring(1, seg.length() - 1));
+    }
+    if (matchOnlyStartEnd('<', '>')) {
+      return new PathSegment.SlashIgnoringParameter(seg.substring(1, seg.length() - 1));
+    }
+
+    return new PathSegment.Literal(seg);
+  }
+
+  private void checkAdjacentViolations() {
+    for (String adjacentViolation : ADJACENT_VIOLATIONS) {
+      if (seg.contains(adjacentViolation)) {
+        throw new IllegalArgumentException("Path [" + rawPath + "] has illegal segment [" + seg + "] that contains [" + adjacentViolation + "]");
+      }
+    }
+  }
+
+  boolean matchOnlyStartEnd(char startChar, char endChar) {
+    return startCharOnly(startChar) && endCharOnly(endChar);
+  }
+
+  boolean startCharOnly(char c) {
+    // first char matches and no subsequent matching char
+    return seg.charAt(0) == c && seg.indexOf(c, 1) == -1;
+  }
+
+  boolean endCharOnly(char c) {
+    // last char matches and no prior matching char
+    return seg.indexOf(c) == seg.length() - 1;
+  }
+
+}

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
@@ -1,34 +1,114 @@
 package io.avaje.jex.routes;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.toList;
+
 class PathSegmentParser {
+
   private static final String[] ADJACENT_VIOLATIONS = {"*{", "*<", "}*", ">*"};
 
-  private final String seg;
+  private static final String NAME_STR = "[a-zA-Z0-9_-]+";
+  private static final String NAME_OPT = "([:][^/^{]+([{][0-9]+[}])?)?"; // Optional regex
+  private static final String SLASH_STR = "[<]" + NAME_STR + "[>]";
+  private static final String PARAM_STR = "[{]" + NAME_STR + NAME_OPT + "[}]";
+  private static final String MULTI_STR = "(" + PARAM_STR + "|" + SLASH_STR + "|[*]|" + "[^{</*]+)";
+
+  private static final Pattern MATCH_PARAM = Pattern.compile(PARAM_STR);
+  private static final Pattern MATCH_MULTI = Pattern.compile(MULTI_STR);
+
+  private final String segment;
   private final String rawPath;
 
-  PathSegmentParser(String seg, String rawPath) {
-    this.seg = seg;
+  PathSegmentParser(String segment, String rawPath) {
+    this.segment = segment;
     this.rawPath = rawPath;
   }
 
   PathSegment parse() {
     checkAdjacentViolations();
-    if (matchOnlyStartEnd('{', '}')) {
-        return new PathSegment.SlashIgnoringParameter(seg.substring(1, seg.length() - 1));
-    }
     if (matchOnlyStartEnd('<', '>')) {
-      return new PathSegment.SlashIgnoringParameter(seg.substring(1, seg.length() - 1));
+      return new PathSegment.SlashAcceptingParameter(trim(segment));
     }
+    if (matchOnlyStartEnd('{', '}')) {
+      return new PathSegment.SlashIgnoringParameter(trim(segment));
+    }
+    if (matchParamWithRegex(segment)) {
+      return new PathSegment.SlashIgnoringParameter(trim(segment));
+    }
+    if (matchLiteral(segment)) {
+      return new PathSegment.Literal(segment);
+    }
+    return parseMultiSegment();
+  }
 
-    return new PathSegment.Literal(seg);
+  private PathSegment parseMultiSegment() {
+    final List<PathSegment> segments = new ArrayList<>();
+    final List<String> tokens = multi(segment);
+
+    int position = 0;
+    StringBuilder appendedTokens = new StringBuilder(segment.length());
+    for (String token : tokens) {
+      appendedTokens.append(token);
+      if (!segment.startsWith(appendedTokens.toString())) {
+        throw new IllegalArgumentException("Path [" + rawPath + "] has illegal segment [" + segment + "] starting at position [" + position + "]");
+      }
+      position += token.length();
+      segments.add(tokenSegment(token));
+    }
+    return new PathSegment.Multi(segments);
+  }
+
+  private PathSegment tokenSegment(String token) {
+    if (token.equals("*")) {
+      return PathSegment.WILDCARD;
+    } else if (token.startsWith("<")) {
+      return slashAccepting(token);
+    } else if (token.startsWith("{")) {
+      return slashIgnoring(token);
+    } else {
+      return new PathSegment.Literal(token);
+    }
+  }
+
+  private PathSegment slashIgnoring(String token) {
+    return new PathSegment.SlashIgnoringParameter(trim(token));
+  }
+
+  private PathSegment slashAccepting(String token) {
+    return new PathSegment.SlashAcceptingParameter(trim(token));
+  }
+
+  static boolean matchParamWithRegex(String input) {
+    return MATCH_PARAM.matcher(input).matches();
+  }
+
+  static List<String> multi(String input) {
+    return MATCH_MULTI.matcher(input).results()
+      .map(MatchResult::group)
+      .collect(toList());
+  }
+
+  static boolean matchLiteral(String segment) {
+    return segment.indexOf('<') == -1
+      && segment.indexOf('{') == -1
+      && segment.indexOf('>') == -1
+      && segment.indexOf('}') == -1;
   }
 
   private void checkAdjacentViolations() {
     for (String adjacentViolation : ADJACENT_VIOLATIONS) {
-      if (seg.contains(adjacentViolation)) {
-        throw new IllegalArgumentException("Path [" + rawPath + "] has illegal segment [" + seg + "] that contains [" + adjacentViolation + "]");
+      if (segment.contains(adjacentViolation)) {
+        throw new IllegalArgumentException("Path [" + rawPath + "] has illegal segment [" + segment + "] that contains [" + adjacentViolation + "]");
       }
     }
+  }
+
+  private String trim(String token) {
+    return token.substring(1, token.length() - 1);
   }
 
   boolean matchOnlyStartEnd(char startChar, char endChar) {
@@ -37,12 +117,12 @@ class PathSegmentParser {
 
   boolean startCharOnly(char c) {
     // first char matches and no subsequent matching char
-    return seg.charAt(0) == c && seg.indexOf(c, 1) == -1;
+    return segment.charAt(0) == c && segment.indexOf(c, 1) == -1;
   }
 
   boolean endCharOnly(char c) {
     // last char matches and no prior matching char
-    return seg.indexOf(c) == seg.length() - 1;
+    return segment.indexOf(c) == segment.length() - 1;
   }
 
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
@@ -9,6 +9,8 @@ import static java.util.stream.Collectors.toList;
 
 class PathSegmentParser {
 
+  private static final PathSegment WILDCARD = new PathSegment.Wildcard();
+
   private static final String[] ADJACENT_VIOLATIONS = {"*{", "*<", "}*", ">*"};
 
   private static final String NAME_STR = "[a-zA-Z0-9_-]+";
@@ -26,6 +28,13 @@ class PathSegmentParser {
   PathSegmentParser(String segment, String rawPath) {
     this.segment = segment;
     this.rawPath = rawPath;
+  }
+
+  static PathSegment parse(String seg, String rawPath) {
+    if (seg.equals("*")) {
+      return WILDCARD;
+    }
+    return new PathSegmentParser(seg, rawPath).parse();
   }
 
   PathSegment parse() {
@@ -64,7 +73,7 @@ class PathSegmentParser {
 
   private PathSegment tokenSegment(String token) {
     if (token.equals("*")) {
-      return PathSegment.WILDCARD;
+      return WILDCARD;
     } else if (token.startsWith("<")) {
       return slashAccepting(token);
     } else if (token.startsWith("{")) {

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
@@ -11,11 +11,15 @@ class RegBuilder {
   private final StringJoiner full = new StringJoiner("/");
   private final StringJoiner extract = new StringJoiner("/");
   private boolean trailingSlash;
+  private boolean includesWildcard;
 
   void add(PathSegment pathSegment, List<String> paramNames) {
     full.add(pathSegment.asRegexString(false));
     extract.add(pathSegment.asRegexString(true));
     pathSegment.addParamName(paramNames);
+    if (!includesWildcard) {
+      includesWildcard = pathSegment.includesWildcard();
+    }
   }
 
   void trailingSlash() {
@@ -43,4 +47,7 @@ class RegBuilder {
     return "^/" + parts + "/?$";
   }
 
+  boolean includesWildcard() {
+    return includesWildcard;
+  }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
@@ -11,14 +11,14 @@ class RegBuilder {
   private final StringJoiner full = new StringJoiner("/");
   private final StringJoiner extract = new StringJoiner("/");
   private boolean trailingSlash;
-  private boolean includesWildcard;
+  private boolean multiSlash;
 
   void add(PathSegment pathSegment, List<String> paramNames) {
     full.add(pathSegment.asRegexString(false));
     extract.add(pathSegment.asRegexString(true));
     pathSegment.addParamName(paramNames);
-    if (!includesWildcard) {
-      includesWildcard = pathSegment.includesWildcard();
+    if (!multiSlash) {
+      multiSlash = pathSegment.multiSlash();
     }
   }
 
@@ -47,7 +47,10 @@ class RegBuilder {
     return "^/" + parts + "/?$";
   }
 
-  boolean includesWildcard() {
-    return includesWildcard;
+  /**
+   * Return true if any of the segments consume unknown number of slashes.
+   */
+  boolean multiSlash() {
+    return multiSlash;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
@@ -58,7 +58,7 @@ class RouteEntry implements SpiRoutes.Entry {
   }
 
   @Override
-  public boolean includesWildcard() {
-    return path.includesWildcard();
+  public boolean multiSlash() {
+    return path.multiSlash();
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
@@ -53,7 +53,7 @@ class RouteEntry implements SpiRoutes.Entry {
   }
 
   @Override
-  public int getSegmentCount() {
+  public int segmentCount() {
     return path.getSegmentCount();
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndex.java
@@ -28,7 +28,7 @@ class RouteIndex {
   }
 
   void add(SpiRoutes.Entry entry) {
-    if (entry.includesWildcard()) {
+    if (entry.multiSlash()) {
       wildcardEntries.add(entry);
     } else {
       entries[index(entry.getSegmentCount())].add(entry);

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndex.java
@@ -31,7 +31,7 @@ class RouteIndex {
     if (entry.multiSlash()) {
       wildcardEntries.add(entry);
     } else {
-      entries[index(entry.getSegmentCount())].add(entry);
+      entries[index(entry.segmentCount())].add(entry);
     }
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/spi/SpiRoutes.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/spi/SpiRoutes.java
@@ -76,9 +76,9 @@ public interface SpiRoutes {
     int getSegmentCount();
 
     /**
-     * Return true if one of the segments is the wildcard match.
+     * Return true if one of the segments is the wildcard match or accepting slashes.
      */
-    boolean includesWildcard();
+    boolean multiSlash();
 
     /**
      * Increment active request count for the route.

--- a/avaje-jex/src/main/java/io/avaje/jex/spi/SpiRoutes.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/spi/SpiRoutes.java
@@ -3,7 +3,6 @@ package io.avaje.jex.spi;
 import io.avaje.jex.Context;
 import io.avaje.jex.Routing;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -108,16 +107,10 @@ public interface SpiRoutes {
     public final Map<String, String> pathParams;
 
     /**
-     * The path splat parameters.
-     */
-    public final List<String> splats;
-
-    /**
      * Create with path parameters and splat/wildcard parameters.
      */
-    public Params(Map<String, String> pathParams, List<String> splats) {
+    public Params(Map<String, String> pathParams) {
       this.pathParams = pathParams;
-      this.splats = splats;
     }
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/spi/SpiRoutes.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/spi/SpiRoutes.java
@@ -73,7 +73,7 @@ public interface SpiRoutes {
     /**
      * Return the segment count.
      */
-    int getSegmentCount();
+    int segmentCount();
 
     /**
      * Return true if one of the segments is the wildcard match or accepting slashes.

--- a/avaje-jex/src/test/java/io/avaje/jex/routes/PathParserTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/routes/PathParserTest.java
@@ -288,7 +288,7 @@ class PathParserTest {
   void multiSegment_mixed() {
     final PathParser pathParser = new PathParser("/{one}/x{two}y{three}z/{four}", true);
     assertThat(pathParser.getSegmentCount()).isEqualTo(3);
-    assertFalse(pathParser.includesWildcard());
+    assertFalse(pathParser.multiSlash());
 
     assertTrue(pathParser.matches("/0/x1y2z/3"));
 
@@ -304,7 +304,7 @@ class PathParserTest {
   void multiSegment_mixed_slashConsuming() {
     final PathParser pathParser = new PathParser("/<one>/x<two>y<three>z/<four>", true);
     assertThat(pathParser.getSegmentCount()).isEqualTo(3);
-    assertTrue(pathParser.includesWildcard());
+    assertTrue(pathParser.multiSlash());
 
     assertTrue(pathParser.matches("/0/x1y2z/3"));
     assertTrue(pathParser.matches("/0/SLASH0/x1/SLASH1y2/SLASH2z/3/SLASH/SLASH"));

--- a/avaje-jex/src/test/java/io/avaje/jex/routes/PathSegmentParserTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/routes/PathSegmentParserTest.java
@@ -1,0 +1,53 @@
+package io.avaje.jex.routes;
+
+import org.junit.jupiter.api.Test;
+
+import static io.avaje.jex.routes.PathSegmentParser.matchParamWithRegex;
+import static io.avaje.jex.routes.PathSegmentParser.multi;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PathSegmentParserTest {
+
+  @Test
+  void matchParamBasic() {
+    assertTrue(matchParamWithRegex("{id}"));
+    assertTrue(matchParamWithRegex("{fooBar}"));
+  }
+
+  @Test
+  void matchParamWithRegexOption() {
+    assertTrue(matchParamWithRegex("{id:[0-9]}"));
+    assertTrue(matchParamWithRegex("{id:[0-9]+}"));
+    assertTrue(matchParamWithRegex("{id:[0-9]{4}}"));
+    assertTrue(matchParamWithRegex("{fooBar:[blah]{108}}"));
+  }
+
+  @Test
+  void matchParamWithRegex_notMatched() {
+    assertFalse(matchParamWithRegex("{id:[0-9]{a}}"));
+    assertFalse(matchParamWithRegex("{id:[0-9]{}}"));
+    assertFalse(matchParamWithRegex("{id:{4}}"));
+    assertFalse(matchParamWithRegex("{:bar{4}}"));
+    assertFalse(matchParamWithRegex("id:[0-9]{4}}"));
+    assertFalse(matchParamWithRegex("{fooBar:[blah]{}}"));
+  }
+
+  @Test
+  void matchMulti() {
+    assertThat(multi("before{id:[0-9]+}<foo>after")).containsExactly("before", "{id:[0-9]+}", "<foo>", "after");
+
+    assertThat(multi("a-<foo>-b")).containsExactly("a-", "<foo>", "-b");
+    assertThat(multi("a-{foo}-b")).containsExactly("a-", "{foo}", "-b");
+    assertThat(multi("a-<foo>-*")).containsExactly("a-", "<foo>", "-", "*");
+    assertThat(multi("a-{foo}-*")).containsExactly("a-", "{foo}", "-", "*");
+    assertThat(multi("a-<foo>.<bar>")).containsExactly("a-", "<foo>", ".", "<bar>");
+  }
+
+  @Test
+  void matchMultiError() {
+    assertThat(multi("a-<foo<bar>>-b")).containsExactly("a-", "foo", "<bar>", ">-b");
+    assertThat(multi("a-{foo{bar}}-b")).containsExactly("a-", "foo", "{bar}", "}-b");
+  }
+}


### PR DESCRIPTION
This follows the approach of Javalin 4.x

So normal path parameters are like `{foo}` and slash accepting path parameters are like `<foo>`.  These can be used to replace splats and make the API more consistent and remove the concept of splats.