### PR TITLE
Fix ExceptionManager to reset buffers before error handling

### DIFF
--- a/avaje-jex-grizzly/src/main/java/io/avaje/jex/grizzly/GrizzlyContext.java
+++ b/avaje-jex-grizzly/src/main/java/io/avaje/jex/grizzly/GrizzlyContext.java
@@ -327,6 +327,14 @@ class GrizzlyContext implements Context, SpiContext {
     return response.getStatus();
   }
 
+  @Override
+  public boolean isCommitted() {
+    return response.isCommitted();
+  }
+
+  public void reset() {
+    response.reset();
+  }
 
   @Override
   public Context json(Object bean) {

--- a/avaje-jex-jdk/src/main/java/io/avaje/jex/jdk/JdkContext.java
+++ b/avaje-jex-jdk/src/main/java/io/avaje/jex/jdk/JdkContext.java
@@ -362,6 +362,17 @@ class JdkContext implements Context, SpiContext {
     os.close();
   }
 
+  @Override
+  public boolean isCommitted() {
+    // no support for this
+    return false;
+  }
+
+  @Override
+  public void reset() {
+    // do nothing
+  }
+
   int statusCode() {
     return statusCode == 0 ? 200 : statusCode;
   }

--- a/avaje-jex-jetty/src/main/java/io/avaje/jex/jetty/JexHttpContext.java
+++ b/avaje-jex-jetty/src/main/java/io/avaje/jex/jetty/JexHttpContext.java
@@ -70,6 +70,16 @@ class JexHttpContext implements SpiContext {
   }
 
   @Override
+  public boolean isCommitted() {
+    return res.isCommitted();
+  }
+
+  @Override
+  public void reset() {
+    res.reset();
+  }
+
+  @Override
   public Context attribute(String key, Object value) {
     req.setAttribute(key, value);
     return this;

--- a/avaje-jex/src/main/java/io/avaje/jex/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Context.java
@@ -298,6 +298,16 @@ public interface Context {
   Context render(String name, Map<String, Object> model);
 
   /**
+   * Return true if content has already been written to the underlying server outputStream.
+   */
+  boolean isCommitted();
+
+  /**
+   * If not committed reset the underlying response status, headers and buffer.
+   */
+  void reset();
+
+  /**
    * Return all the request headers as a map.
    */
   Map<String, String> headerMap();


### PR DESCRIPTION
- Add Context isCommitted() and reset()
- Modify ExceptionManager to use these to reset response buffer before error handler writes error content
- Note that there is a related fix in avaje-jsonb 1.1-RC1