### PR TITLE
[JDK Server] Write more than a single byte at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ build/
 .idea/
 *.iml
 .gradle
+.project
+*.prefs
+avaje-jex-jdk/.classpath
+avaje-jex-jetty/.classpath
+avaje-jex/.classpath

--- a/avaje-jex-jdk/src/main/java/io/avaje/jex/jdk/BufferedOutStream.java
+++ b/avaje-jex-jdk/src/main/java/io/avaje/jex/jdk/BufferedOutStream.java
@@ -32,6 +32,19 @@ class BufferedOutStream extends OutputStream {
     }
   }
 
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    if (stream != null) {
+      stream.write(b, off, len);
+    } else {
+      count += len;
+      buffer.write(b, off, len);
+      if (count > max) {
+        initialiseChunked();
+      }
+    }
+  }
+
   /**
    * Use responseLength 0 and chunked response.
    */


### PR DESCRIPTION
When directly subclassing `java.io.OutputStream`, you only need to implement the method `write(int)`. However most uses for such streams don’t write a single byte at a time and the default implementation for `write(byte[],int,int)` will call `write(int)` for every single byte in the array which can create a lot of overhead and is utterly inefficient.