### PR TITLE
Handle No Response

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkContext.java
@@ -48,7 +48,7 @@ class JdkContext implements Context, SpiContext {
   private Map<String, List<String>> formParams;
   private Map<String, List<String>> queryParams;
   private Map<String, String> cookieMap;
-  private int statusCode;
+  private int statusCode = 200;
   private String characterEncoding;
 
   JdkContext(

--- a/avaje-jex/src/main/java/io/avaje/jex/jdk/RoutingFilter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/jdk/RoutingFilter.java
@@ -1,5 +1,6 @@
 package io.avaje.jex.jdk;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,6 +43,7 @@ final class RoutingFilter extends Filter {
         processNoRoute(ctx, uri, routeType);
         exchange.setAttribute("JdkContext", ctx);
         chain.doFilter(exchange);
+        handleNoResponse(exchange);
       } catch (Exception e) {
         handleException(ctx, e);
       } finally {
@@ -59,6 +61,7 @@ final class RoutingFilter extends Filter {
           ExchangeHandler handlerConsumer = route::handle;
           exchange.setAttribute("SpiRoutes.Entry.Handler", handlerConsumer);
           chain.doFilter(exchange);
+          handleNoResponse(exchange);
         } catch (Exception e) {
           handleException(ctx, e);
         }
@@ -66,6 +69,13 @@ final class RoutingFilter extends Filter {
         route.dec();
         exchange.close();
       }
+    }
+  }
+
+  private void handleNoResponse(HttpExchange exchange) throws IOException {
+
+    if (exchange.getResponseCode() == -1) {
+      exchange.sendResponseHeaders(204, -1);
     }
   }
 

--- a/avaje-jex/src/test/java/io/avaje/jex/jdk/FilterTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/jdk/FilterTest.java
@@ -23,6 +23,7 @@ class FilterTest {
                 routing ->
                     routing
                         .get("/", ctx -> ctx.text("roo"))
+                        .get("/noResponse", ctx -> {})
                         .get("/one", ctx -> ctx.text("one"))
                         .get("/two", ctx -> ctx.text("two"))
                         .get("/two/{id}", ctx -> ctx.text("two-id"))
@@ -73,6 +74,15 @@ class FilterTest {
 
     clearAfter();
     res = pair.request().path("two").GET().asString();
+    assertHasBeforeAfterAll(res);
+    assertNoBeforeAfterTwo(res);
+  }
+
+  @Test
+  void getNoResponse() {
+    clearAfter();
+    HttpResponse<String> res = pair.request().path("noResponse").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(204);
     assertHasBeforeAfterAll(res);
     assertNoBeforeAfterTwo(res);
   }


### PR DESCRIPTION
Handle cases where people forget to set the response like

```java
Jex.create().routing(routing -> routing.get("/noResponse", ctx -> {}));
```