### PR TITLE
Use explicit close rather than try-with-resources for AutoClosable it…

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceManager.java
@@ -76,8 +76,8 @@ public final class CoreServiceManager implements SpiServiceManager {
   @Override
   public void maybeClose(Object iterator) {
     if (iterator instanceof AutoCloseable closeable) {
-      try (closeable) {
-        // nothing
+      try {
+        closeable.close();
       } catch (Exception e) {
         throw new RuntimeException("Error closing iterator " + iterator, e);
       }

--- a/avaje-jex/src/test/java/io/avaje/jex/jdk/AutoCloseIterator.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/jdk/AutoCloseIterator.java
@@ -1,11 +1,12 @@
 package io.avaje.jex.jdk;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AutoCloseIterator<E> implements Iterator<E>, AutoCloseable {
 
   private final Iterator<E> it;
-  private volatile boolean closed;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   public AutoCloseIterator(Iterator<E> it) {
     this.it = it;
@@ -23,10 +24,10 @@ public class AutoCloseIterator<E> implements Iterator<E>, AutoCloseable {
 
   @Override
   public void close() {
-    closed = true;
+    closed.set(true);
   }
 
   public boolean isClosed() {
-    return closed;
+    return closed.get();
   }
 }

--- a/avaje-jex/src/test/java/io/avaje/jex/jdk/FilterTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/jdk/FilterTest.java
@@ -75,7 +75,7 @@ class FilterTest {
 
     clearAfter();
     res = pair.request().path("two").GET().asString();
-    LockSupport.parkNanos(TimeUnit.NANOSECONDS.toMillis(10));
+    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
     assertHasBeforeAfterAll(res);
     assertNoBeforeAfterTwo(res);
   }

--- a/avaje-jex/src/test/java/io/avaje/jex/jdk/JsonTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/jdk/JsonTest.java
@@ -7,6 +7,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
@@ -69,6 +71,7 @@ class JsonTest {
     // expect client gets the expected stream of beans
     assertCollectedStream(beanStream);
     // assert AutoCloseable iterator on the server-side was closed
+    LockSupport.parkNanos(TimeUnit.NANOSECONDS.toMillis(10));
     assertThat(ITERATOR.isClosed()).isTrue();
   }
 

--- a/avaje-jex/src/test/java/io/avaje/jex/jdk/JsonTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/jdk/JsonTest.java
@@ -71,7 +71,7 @@ class JsonTest {
     // expect client gets the expected stream of beans
     assertCollectedStream(beanStream);
     // assert AutoCloseable iterator on the server-side was closed
-    LockSupport.parkNanos(TimeUnit.NANOSECONDS.toMillis(10));
+    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
     assertThat(ITERATOR.isClosed()).isTrue();
   }
 


### PR DESCRIPTION
…erator

This way the close() is executed before the catch block rather than after