### PR TITLE
Fix Static Directories paths 

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/StaticResourceHandlerBuilder.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/StaticResourceHandlerBuilder.java
@@ -63,7 +63,7 @@ final class StaticResourceHandlerBuilder implements StaticContentConfig {
 
   @Override
   public StaticResourceHandlerBuilder httpPath(String path) {
-    this.path = path;
+    this.path = path.endsWith("/") ? path + "*" : path;
     return this;
   }
 

--- a/avaje-jex/src/test/java/io/avaje/jex/StaticFileTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/StaticFileTest.java
@@ -22,7 +22,7 @@ class StaticFileTest {
             .staticResource(b -> defaultFile(b.httpPath("/indexFile")))
             .staticResource(b -> defaultCP(b.httpPath("/indexWild/*")))
             .staticResource(b -> defaultFile(b.httpPath("/indexWildFile/*")))
-            .staticResource(b -> defaultCP(b.httpPath("/sus/*")))
+            .staticResource(b -> defaultCP(b.httpPath("/sus/")))
             .staticResource(b -> defaultFile(b.httpPath("/susFile/*")))
             .staticResource(b -> b.httpPath("/single").resource("/logback.xml"))
             .staticResource(


### PR DESCRIPTION
Before you needed to specify `/*` in the static config path if you wanted to read the directory contents for some reason.