### PR TITLE
Remove Applog Dependency

### DIFF
--- a/avaje-jex/pom.xml
+++ b/avaje-jex/pom.xml
@@ -16,12 +16,6 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
-      <artifactId>avaje-applog</artifactId>
-      <version>1.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
       <version>4.0</version>
       <optional>true</optional>

--- a/avaje-jex/src/main/java/io/avaje/jex/DefaultLifecycle.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DefaultLifecycle.java
@@ -1,9 +1,6 @@
 package io.avaje.jex;
 
-import io.avaje.applog.AppLog;
-
 import java.lang.System.Logger.Level;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,7 +10,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 final class DefaultLifecycle implements AppLifecycle {
 
-  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
+  private static final System.Logger log = System.getLogger("io.avaje.jex");
 
   private final List<Pair> shutdownRunnable = new ArrayList<>();
   private final ReentrantLock lock = new ReentrantLock();

--- a/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceManager.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.avaje.applog.AppLog;
 import io.avaje.jex.Context;
 import io.avaje.jex.Jex;
 import io.avaje.jex.Routing;
@@ -29,7 +28,7 @@ import io.avaje.jex.spi.TemplateRender;
  */
 public final class CoreServiceManager implements SpiServiceManager {
 
-  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
+  private static final System.Logger log = System.getLogger("io.avaje.jex");
   public static final String UTF_8 = "UTF-8";
 
   private final HttpMethodMap methodMap = new HttpMethodMap();

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ExceptionManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ExceptionManager.java
@@ -1,10 +1,9 @@
 package io.avaje.jex.core;
 
-import static java.lang.System.Logger.Level.WARNING;
+import static java.lang.System.Logger.Level.ERROR;
 
 import java.util.Map;
 
-import io.avaje.applog.AppLog;
 import io.avaje.jex.Context;
 import io.avaje.jex.ExceptionHandler;
 import io.avaje.jex.http.ErrorCode;
@@ -16,7 +15,7 @@ public final class ExceptionManager {
 
   private static final String APPLICATION_JSON = "application/json";
 
-  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
+  private static final System.Logger log = System.getLogger("io.avaje.jex");
 
   private final Map<Class<?>, ExceptionHandler<?>> handlers;
 
@@ -53,7 +52,7 @@ public final class ExceptionManager {
   }
 
   private void unhandledException(JdkContext ctx, Exception e) {
-    log.log(WARNING, "Uncaught exception", e);
+    log.log(ERROR, "Uncaught exception", e);
     defaultHandling(ctx, new InternalServerErrorException(ErrorCode.INTERNAL_SERVER_ERROR.message()));
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkJexServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkJexServer.java
@@ -1,15 +1,15 @@
 package io.avaje.jex.jdk;
 
+import java.lang.System.Logger.Level;
+
 import com.sun.net.httpserver.HttpServer;
-import io.avaje.applog.AppLog;
+
 import io.avaje.jex.AppLifecycle;
 import io.avaje.jex.Jex;
 
-import java.lang.System.Logger.Level;
-
 final class JdkJexServer implements Jex.Server {
 
-  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
+  private static final System.Logger log = System.getLogger("io.avaje.jex");
 
   private final HttpServer server;
   private final AppLifecycle lifecycle;

--- a/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkServerStart.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkServerStart.java
@@ -9,7 +9,6 @@ import java.net.UnknownHostException;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsServer;
 
-import io.avaje.applog.AppLog;
 import io.avaje.jex.AppLifecycle;
 import io.avaje.jex.Jex;
 import io.avaje.jex.JexConfig;
@@ -20,7 +19,7 @@ import static java.lang.System.Logger.Level.INFO;
 
 public final class JdkServerStart {
 
-  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
+  private static final System.Logger log = System.getLogger("io.avaje.jex");
 
   public Jex.Server start(Jex jex, SpiRoutes routes, SpiServiceManager serviceManager) {
     try {

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
@@ -6,13 +6,12 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 
-import io.avaje.applog.AppLog;
 import io.avaje.jex.HttpFilter;
 import io.avaje.jex.Routing;
 
 final class Routes implements SpiRoutes {
 
-  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
+  private static final System.Logger log = System.getLogger("io.avaje.jex");
 
   /**
    * The "real" handlers by http method.

--- a/avaje-jex/src/main/java/module-info.java
+++ b/avaje-jex/src/main/java/module-info.java
@@ -29,7 +29,6 @@ module io.avaje.jex {
 
   requires transitive java.net.http;
   requires transitive jdk.httpserver;
-  requires transitive io.avaje.applog;
   requires static com.fasterxml.jackson.core;
   requires static com.fasterxml.jackson.databind;
   requires static io.avaje.jsonb;


### PR DESCRIPTION
[Says here](https://github.com/avaje/avaje-applog?tab=readme-ov-file#how-to-use) that applog is mainly used for when an application does not have a dedicated JVM. (like AWS lambda)

Is there a reason to have this dependency for something guaranteed not to be deployed on stuff like lambda?