### PR TITLE
Expose Context.outputStream() such that outputStream can be used directly

### DIFF
--- a/avaje-jex/pom.xml
+++ b/avaje-jex/pom.xml
@@ -48,6 +48,12 @@
       <optional>true</optional>
     </dependency>
 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb-generator</artifactId>
+      <version>2.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/avaje-jex/src/main/java/io/avaje/jex/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Context.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Iterator;
@@ -293,6 +294,15 @@ public interface Context {
    * @param is The input stream containing the content to write.
    */
   Context write(InputStream is);
+
+  /**
+   * Return the outputStream to write content. It is expected that
+   * the {@link #contentType(String)} has been set prior to obtaining
+   * and writing to the outputStream.
+   *
+   * @return The outputStream to write content to.
+   */
+  OutputStream outputStream();
 
   /**
    * Render a template typically as html.

--- a/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/jdk/JdkContext.java
@@ -477,6 +477,7 @@ public final class JdkContext implements Context {
     return exchange.getProtocol();
   }
 
+  @Override
   public OutputStream outputStream() {
     var out = mgr.createOutputStream(this);
     if (compressionConfig.compressionEnabled()) {

--- a/avaje-jex/src/test/java/io/avaje/jex/jdk/HelloDto.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/jdk/HelloDto.java
@@ -1,5 +1,8 @@
 package io.avaje.jex.jdk;
 
+import io.avaje.jsonb.Json;
+
+@Json
 public class HelloDto {
 
   public long id;


### PR DESCRIPTION
For example, with Jsonb we can obtain the specific type once and then write directly to the outputSteam like:
```java
ctx.status(200).contentType("application/json");
var result = HelloDto.rob();
jsonTypeHelloDto.toJson(result, ctx.outputStream());
```
... where jsonTypeHelloDto is obtained like:

```java
static final Jsonb jsonb = Jsonb.builder().build();
static final JsonType<HelloDto> jsonTypeHelloDto = jsonb.type(HelloDto.class);
```

With this approach, it effectively bypasses the underlying io.avaje.jex.spi.JsonService with the view that this can be more flexible and more efficient.