### PR TITLE
Rename JdkServerStart to BootstrapServer, more classes non-public

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/DJex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJex.java
@@ -1,11 +1,7 @@
 package io.avaje.jex;
 
 import io.avaje.inject.BeanScope;
-import io.avaje.jex.core.CoreServiceLoader;
-import io.avaje.jex.core.HealthPlugin;
-import io.avaje.jex.core.JdkServerStart;
-import io.avaje.jex.routes.RoutesBuilder;
-import io.avaje.jex.routes.SpiRoutes;
+import io.avaje.jex.core.BootstrapServer;
 import io.avaje.jex.spi.*;
 
 import java.util.*;
@@ -108,18 +104,6 @@ final class DJex implements Jex {
 
   @Override
   public Server start() {
-    if (config.health()) {
-      plugin(new HealthPlugin());
-    }
-
-    if (config.useSpiPlugins()) {
-      CoreServiceLoader.plugins().forEach(p -> p.apply(this));
-    }
-
-    final SpiRoutes routes =
-        new RoutesBuilder(routing, config.ignoreTrailingSlashes())
-            .build();
-
-    return new JdkServerStart().start(this, routes);
+    return BootstrapServer.start(this);
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
@@ -164,7 +164,8 @@ final class DJexConfig implements JexConfig {
     return this;
   }
 
-  boolean useSpiPlugins() {
+  @Override
+  public boolean useSpiPlugins() {
     return useJexSpi;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -145,4 +145,7 @@ public sealed interface JexConfig permits DJexConfig {
 
   /** Return the socket backlog. */
   int socketBacklog();
+
+  /** Return true if SPI plugins should be loaded and registered. */
+  boolean useSpiPlugins();
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
@@ -1,27 +1,44 @@
 package io.avaje.jex.core;
 
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsServer;
+import io.avaje.applog.AppLog;
+import io.avaje.jex.AppLifecycle;
+import io.avaje.jex.Jex;
+import io.avaje.jex.JexConfig;
+import io.avaje.jex.routes.RoutesBuilder;
+import io.avaje.jex.routes.SpiRoutes;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
-import com.sun.net.httpserver.HttpServer;
-import com.sun.net.httpserver.HttpsServer;
-
-import io.avaje.applog.AppLog;
-import io.avaje.jex.AppLifecycle;
-import io.avaje.jex.Jex;
-import io.avaje.jex.JexConfig;
-import io.avaje.jex.routes.SpiRoutes;
-
 import static java.lang.System.Logger.Level.INFO;
 
-public final class JdkServerStart {
+public class BootstrapServer {
 
   private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 
-  public Jex.Server start(Jex jex, SpiRoutes routes) {
+  public static Jex.Server start(Jex jex) {
+    final var config = jex.config();
+    if (config.health()) {
+      jex.plugin(new HealthPlugin());
+    }
+
+    if (config.useSpiPlugins()) {
+      CoreServiceLoader.plugins().forEach(p -> p.apply(jex));
+    }
+
+    final SpiRoutes routes =
+      new RoutesBuilder(jex.routing(), config.ignoreTrailingSlashes())
+        .build();
+
+    return start(jex, routes);
+  }
+
+  static Jex.Server start(Jex jex, SpiRoutes routes) {
     SpiServiceManager serviceManager = CoreServiceManager.create(jex);
     try {
       final var config = jex.config();

--- a/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
@@ -17,7 +17,7 @@ import java.net.UnknownHostException;
 
 import static java.lang.System.Logger.Level.INFO;
 
-public class BootstrapServer {
+public final class BootstrapServer {
 
   private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceLoader.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceLoader.java
@@ -11,7 +11,7 @@ import io.avaje.jex.spi.JsonService;
 import io.avaje.jex.spi.TemplateRender;
 
 /** Core implementation of SpiServiceManager provided to specific implementations like jetty etc. */
-public final class CoreServiceLoader {
+final class CoreServiceLoader {
 
   private static final CoreServiceLoader INSTANCE = new CoreServiceLoader();
 
@@ -31,15 +31,15 @@ public final class CoreServiceLoader {
     jsonService = spiJsonService;
   }
 
-  public static Optional<JsonService> jsonService() {
+  static Optional<JsonService> jsonService() {
     return Optional.ofNullable(INSTANCE.jsonService);
   }
 
-  public static List<TemplateRender> getRenders() {
+  static List<TemplateRender> getRenders() {
     return INSTANCE.renders;
   }
 
-  public static List<JexPlugin> plugins() {
+  static List<JexPlugin> plugins() {
     return INSTANCE.plugins;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceManager.java
@@ -140,7 +140,8 @@ final class CoreServiceManager implements SpiServiceManager {
     }
   }
 
-  private static class Builder {
+  private static final class Builder {
+
     private final Jex jex;
 
     Builder(Jex jex) {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/CtxServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/CtxServiceManager.java
@@ -30,11 +30,7 @@ final class CtxServiceManager implements SpiServiceManager {
     return scheme;
   }
 
-  public String url() {
-    return scheme + "://";
-  }
-
-  public String contextPath() {
+  String contextPath() {
     return contextPath;
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/HealthPlugin.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/HealthPlugin.java
@@ -9,7 +9,7 @@ import io.avaje.jex.spi.JexPlugin;
  * Health plugin with liveness and readiness support based on
  * the application lifecycle support.
  */
-public final class HealthPlugin implements JexPlugin {
+final class HealthPlugin implements JexPlugin {
 
   private AppLifecycle lifecycle;
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -485,7 +485,7 @@ final class JdkContext implements Context {
     return out;
   }
 
-  public void setMode(Mode type) {
+  void setMode(Mode type) {
     this.mode = type;
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/TemplateManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/TemplateManager.java
@@ -11,16 +11,15 @@ import java.util.Set;
 /**
  * Render templates typically as html.
  */
-public final class TemplateManager {
+final class TemplateManager {
 
   private final Map<String, TemplateRender> map = new HashMap<>();
-
   private final Set<Class<?>> renderTypes = new HashSet<>();
 
   /**
    * Register all the extension renderer pairs.
    */
-  public void register(Map<String, TemplateRender> source) {
+  void register(Map<String, TemplateRender> source) {
     map.putAll(source);
     map.values().forEach(templateRender -> renderTypes.add(templateRender.getClass()));
   }
@@ -28,7 +27,7 @@ public final class TemplateManager {
   /**
    * Auto register via ServiceLoader if it has not already been explicitly registered.
    */
-  public void registerDefault(TemplateRender render) {
+  void registerDefault(TemplateRender render) {
     if (!renderTypes.contains(render.getClass())) {
       for (String extension : render.defaultExtensions()) {
         map.computeIfAbsent(extension, k->render);
@@ -39,7 +38,7 @@ public final class TemplateManager {
   /**
    * Register an extension and renderer.
    */
-  public void register(String extn, TemplateRender renderer) {
+  void register(String extn, TemplateRender renderer) {
     map.put(extn, renderer);
   }
 
@@ -50,7 +49,7 @@ public final class TemplateManager {
    * @param name  The name of the template
    * @param model The model key value pairs to render use with the template
    */
-  public void render(Context ctx, String name, Map<String, Object> model) {
+  void render(Context ctx, String name, Map<String, Object> model) {
     final String extn = extension(name);
     if (extn == null) {
       throw new IllegalArgumentException("No extension, not handled yet - " + name);


### PR DESCRIPTION
- Rename JdkServerStart to BootstrapServer
- Move all bootstrap logic into BootstrapServer
- Make more classes in core non-public