### PR TITLE
Improve flaky test FilterTest (with after filter)

### DIFF
--- a/avaje-jex/src/test/java/io/avaje/jex/core/FilterTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/FilterTest.java
@@ -74,7 +74,6 @@ class FilterTest {
 
     clearAfter();
     res = pair.request().path("two").GET().asString();
-    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
     assertHasBeforeAfterAll(res);
     assertNoBeforeAfterTwo(res);
   }
@@ -106,6 +105,7 @@ class FilterTest {
 
   private void assertHasBeforeAfterAll(HttpResponse<String> res) {
     assertThat(res.headers().firstValue("before-all")).get().isEqualTo("set");
+    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(2));
     assertThat(afterAll.get()).isEqualTo("set");
   }
 }


### PR DESCRIPTION
The after filter actions can occur after the response has been sent back to the client, so the client thread can execute before the actual after filter action has completed for these tests.