### PR TITLE
Fix path ordering route building issue - RouteIndexBuild.Entry.pathMa…

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
@@ -15,6 +15,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 
 public final class BootstrapServer {
@@ -67,6 +68,7 @@ public final class BootstrapServer {
           "started com.sun.net.httpserver.HttpServer on port {0}://{1}",
           scheme,
           socketAddress);
+      log.log(DEBUG, routes);
       return new JdkJexServer(server, jex.lifecycle(), handler);
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
@@ -80,4 +80,9 @@ final class RouteEntry implements SpiRoutes.Entry {
   public Set<Role> roles() {
     return roles;
   }
+
+  @Override
+  public String toString() {
+    return path.raw();
+  }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndex.java
@@ -1,5 +1,6 @@
 package io.avaje.jex.routes;
 
+import java.util.Arrays;
 import java.util.List;
 
 final class RouteIndex {
@@ -20,6 +21,13 @@ final class RouteIndex {
       .map(RouteIndex::toEntry)
       .toList()
       .toArray(new IndexEntry[0]);
+  }
+
+  @Override
+  public String toString() {
+    return "RouteIndex{" + Arrays.toString(entries) +
+      ", wildcards=" + Arrays.toString(wildcardEntries) +
+      '}';
   }
 
   private static IndexEntry toEntry(List<SpiRoutes.Entry> routeEntries) {
@@ -75,6 +83,11 @@ final class RouteIndex {
 
     IndexEntry(SpiRoutes.Entry[] pathEntries) {
       this.pathEntries = pathEntries;
+    }
+
+    @Override
+    public String toString() {
+      return Arrays.toString(pathEntries);
     }
 
     SpiRoutes.Entry match(String pathInfo) {

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndexBuild.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteIndexBuild.java
@@ -2,10 +2,7 @@ package io.avaje.jex.routes;
 
 import io.avaje.jex.ExchangeHandler;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Build the RouteIndex.
@@ -54,7 +51,7 @@ final class RouteIndexBuild {
   private static class Entry {
 
     private final List<SpiRoutes.Entry> list = new ArrayList<>();
-    private final Map<String,List<SpiRoutes.Entry>> pathMap = new HashMap<>();
+    private final Map<String,List<SpiRoutes.Entry>> pathMap = new LinkedHashMap<>();
 
     void add(SpiRoutes.Entry entry) {
       if (entry.literal()) {

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
@@ -25,10 +25,14 @@ final class Routes implements SpiRoutes {
 
   private final AtomicLong noRouteCounter = new AtomicLong();
 
-
   Routes(EnumMap<Routing.Type, RouteIndex> typeMap, List<HttpFilter> filters) {
     this.typeMap = typeMap;
     this.filters = filters;
+  }
+
+  @Override
+  public String toString() {
+    return "Routes{" + typeMap + ", filters=" + filters + '}';
   }
 
   @Override


### PR DESCRIPTION
…p as LinkedHashMap

The RouteIndexBuild.Entry.pathMap needs to preserve ordering of the routes. The order that they are added/registered must be preserved. This is the precedence of route matching where the first match wins (literal paths should match first etc).