### PR TITLE
Fix jex-test failing without jackson

### DIFF
--- a/avaje-jex-test/pom.xml
+++ b/avaje-jex-test/pom.xml
@@ -14,14 +14,14 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jex</artifactId>
-      <version>3.0-RC7</version>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-http-client</artifactId>
-      <version>2.8</version>
+      <version>2.9-RC4</version>
     </dependency>
 
     <!-- dependency injection component testing -->
@@ -33,17 +33,9 @@
     </dependency>
 
     <dependency>
-      <groupId>io.avaje</groupId>
-      <artifactId>avaje-jsonb</artifactId>
-      <version>2.3</version>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
-      <optional>true</optional>
     </dependency>
 
   </dependencies>

--- a/avaje-jex-test/src/main/java/io/avaje/jex/test/TestPair.java
+++ b/avaje-jex-test/src/main/java/io/avaje/jex/test/TestPair.java
@@ -1,11 +1,10 @@
 package io.avaje.jex.test;
 
+import java.util.Random;
+
 import io.avaje.http.client.HttpClient;
 import io.avaje.http.client.HttpClientRequest;
-import io.avaje.http.client.JacksonBodyAdapter;
 import io.avaje.jex.Jex;
-
-import java.util.Random;
 
 /**
  * Server and Client pair for a test.
@@ -51,7 +50,6 @@ public class TestPair {
     var url = "http://localhost:" + port;
     var client = HttpClient.builder()
       .baseUrl(url)
-      .bodyAdapter(new JacksonBodyAdapter())
       .build();
 
     return new TestPair(port, jexServer, client);

--- a/avaje-jex-test/src/main/java/module-info.java
+++ b/avaje-jex-test/src/main/java/module-info.java
@@ -4,10 +4,8 @@ open module io.avaje.jex.test {
 
   requires transitive io.avaje.jex;
   requires transitive io.avaje.http.client;
-  requires static com.fasterxml.jackson.databind;
-  requires static io.avaje.jsonb;
+  requires transitive com.fasterxml.jackson.databind;
   requires static io.avaje.inject.test;
-  requires static org.apiguardian.api; // stink man !!
 
   provides io.avaje.inject.test.Plugin with io.avaje.jex.test.JexInjectPlugin;
 }


### PR DESCRIPTION
Fixes error when no json libraries are available on the class path when testing