### PR TITLE
Make avaje processors provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,42 +116,57 @@
         <groupId>io.avaje</groupId>
         <artifactId>avaje-http-client-generator</artifactId>
         <version>${avaje.http.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-http-jex-generator</artifactId>
         <version>${avaje.http.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-inject-generator</artifactId>
         <version>${avaje.inject.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-jsonb-generator</artifactId>
         <version>${avaje.jsonb.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-validator-generator</artifactId>
         <version>${avaje.validator.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-prisms</artifactId>
         <version>${avaje.prisms.version}</version>
+        <scope>provided</scope>
         <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-record-builder</artifactId>
         <version>${avaje.record.builder.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>
         <artifactId>avaje-spi-service</artifactId>
         <version>${avaje.spi.version}</version>
+        <scope>provided</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.avaje</groupId>


### PR DESCRIPTION
The parent pom now sets the default maven scope of the avaje annotation processors to `provided`. This can help prevent accidentally using them with `compile` scope