### PR TITLE
Make response buffer configurable

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
@@ -26,6 +26,8 @@ final class DJexConfig implements JexConfig {
   private HttpsConfigurator httpsConfig;
   private boolean useJexSpi = true;
   private final CompressionConfig compression = new CompressionConfig();
+  private int bufferInitial = 256;
+  private long bufferMax = 1024L;
 
   @Override
   public JexConfig host(String host) {
@@ -170,5 +172,27 @@ final class DJexConfig implements JexConfig {
   @Override
   public boolean useSpiPlugins() {
     return useJexSpi;
+  }
+
+  @Override
+  public long maxStreamBufferSize() {
+    return bufferMax;
+  }
+
+  @Override
+  public int initialStreamBufferSize() {
+    return bufferInitial;
+  }
+
+  @Override
+  public JexConfig initialStreamBufferSize(int initialSize) {
+    bufferInitial = initialSize;
+    return this;
+  }
+
+  @Override
+  public JexConfig maxStreamBufferSize(long maxSize) {
+    bufferMax = maxSize;
+    return this;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -49,7 +49,8 @@ public sealed interface JexConfig permits DJexConfig {
   JexConfig disableSpiPlugins();
 
   /**
-   * Executor for serving requests. Defaults to a {@link Executors#newVirtualThreadPerTaskExecutor()}
+   * Executor for serving requests. Defaults to a {@link
+   * Executors#newVirtualThreadPerTaskExecutor()}
    */
   Executor executor();
 
@@ -100,6 +101,19 @@ public sealed interface JexConfig permits DJexConfig {
    */
   JexConfig ignoreTrailingSlashes(boolean ignoreTrailingSlashes);
 
+  /** The initial size of the response buffer */
+  int initialStreamBufferSize();
+
+  /**
+   * Set the initial size of the response stream buffer. If exceeded, the buffer will expand until
+   * it reaches the maximum configured size
+   *
+   * <p>Defaults to 256
+   *
+   * @param initialSize The initial size of the response buffer
+   */
+  JexConfig initialStreamBufferSize(int initialSize);
+
   /** Returns the configured JSON service. */
   JsonService jsonService();
 
@@ -109,6 +123,20 @@ public sealed interface JexConfig permits DJexConfig {
    * @param jsonService The json service instance.
    */
   JexConfig jsonService(JsonService jsonService);
+
+  /** the maximum size of the response stream buffer. */
+  long maxStreamBufferSize();
+
+  /**
+   * Set the maximum size of the response stream buffer. If the response data exceeds this size,
+   * then it will be written to the client using chunked transfer encoding. Otherwise, the response
+   * will be sent using a Content-Length header with the exact size of the response data.
+   *
+   * <p>Defaults to 1024
+   *
+   * @param maxSize The maximum size of the response
+   */
+  JexConfig maxStreamBufferSize(long maxSize);
 
   /** Returns the configured port number. (Defaults to 8080 if not set) */
   int port();

--- a/avaje-jex/src/main/java/io/avaje/jex/core/BufferedOutStream.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BufferedOutStream.java
@@ -28,7 +28,7 @@ final class BufferedOutStream extends OutputStream {
     } else {
       if (count++ > max) {
         initialiseChunked();
-        write(b);
+        stream.write(b);
         return;
       }
       buffer.write(b);
@@ -43,7 +43,7 @@ final class BufferedOutStream extends OutputStream {
       count += len;
       if (count > max) {
         initialiseChunked();
-        write(b, off, len);
+        stream.write(b, off, len);
         return;
       }
       buffer.write(b, off, len);

--- a/avaje-jex/src/main/java/io/avaje/jex/core/BufferedOutStream.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BufferedOutStream.java
@@ -8,18 +8,17 @@ import com.sun.net.httpserver.HttpExchange;
 
 final class BufferedOutStream extends OutputStream {
 
-  private static final long MAX = Long.getLong("jex.outputBuffer.max", 1024);
-  private static final int INITIAL =
-      Integer.getInteger("jex.outputBuffer.initial", 256);
-
+  private final long max;
   private final JdkContext context;
   private ByteArrayOutputStream buffer;
   private OutputStream stream;
   private long count;
 
-  BufferedOutStream(JdkContext context) {
+  BufferedOutStream(JdkContext context, int initial, long max) {
+
     this.context = context;
-    this.buffer = new ByteArrayOutputStream(INITIAL);
+    this.max = max;
+    this.buffer = new ByteArrayOutputStream(initial);
   }
 
   @Override
@@ -27,10 +26,12 @@ final class BufferedOutStream extends OutputStream {
     if (stream != null) {
       stream.write(b);
     } else {
-      buffer.write(b);
-      if (count++ > MAX) {
+      if (count++ > max) {
         initialiseChunked();
+        write(b);
+        return;
       }
+      buffer.write(b);
     }
   }
 
@@ -40,10 +41,12 @@ final class BufferedOutStream extends OutputStream {
       stream.write(b, off, len);
     } else {
       count += len;
-      buffer.write(b, off, len);
-      if (count > MAX) {
+      if (count > max) {
         initialiseChunked();
+        write(b, off, len);
+        return;
       }
+      buffer.write(b, off, len);
     }
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/SpiServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/SpiServiceManager.java
@@ -35,6 +35,8 @@ final class SpiServiceManager {
   private final TemplateManager templateManager;
   private final String scheme;
   private final String contextPath;
+  private final int bufferInitial;
+  private final long bufferMax;
 
   static SpiServiceManager create(Jex jex) {
     return new Builder(jex).build();
@@ -45,16 +47,20 @@ final class SpiServiceManager {
       ExceptionManager manager,
       TemplateManager templateManager,
       String scheme,
-      String contextPath) {
+      String contextPath,
+      long bufferMax,
+      int bufferInitial) {
     this.jsonService = jsonService;
     this.exceptionHandler = manager;
     this.templateManager = templateManager;
     this.scheme = scheme;
     this.contextPath = contextPath;
+    this.bufferInitial = bufferInitial;
+    this.bufferMax = bufferMax;
   }
 
   OutputStream createOutputStream(JdkContext jdkContext) {
-    return new BufferedOutStream(jdkContext);
+    return new BufferedOutStream(jdkContext, bufferInitial, bufferMax);
   }
 
   <T> T fromJson(Class<T> type, InputStream is) {
@@ -165,7 +171,9 @@ final class SpiServiceManager {
           new ExceptionManager(jex.routing().errorHandlers()),
           initTemplateMgr(),
           jex.config().scheme(),
-          jex.config().contextPath());
+          jex.config().contextPath(),
+          jex.config().maxStreamBufferSize(),
+          jex.config().initialStreamBufferSize());
     }
 
     JsonService initJsonService() {


### PR DESCRIPTION
- Can now configure the buffer size via `JexConfig`
- Skip last write to buffer if size will be exceeded

Feel free to change the names