### PR TITLE
Fix ignore trailing slashes

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/Jex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Jex.java
@@ -104,7 +104,7 @@ public sealed interface Jex permits DJex {
    * @param roles An array of roles that are associated with this endpoint.
    */
   default Jex put(String path, ExchangeHandler handler, Role... roles) {
-    routing().get(path, handler, roles);
+    routing().put(path, handler, roles);
     return this;
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
@@ -16,7 +16,7 @@ final class PathParser {
 
   PathParser(String path, boolean ignoreTrailingSlashes) {
     this.rawPath = path;
-    final RegBuilder regBuilder = new RegBuilder();
+    final RegBuilder regBuilder = new RegBuilder(ignoreTrailingSlashes);
     for (String rawSeg : path.split("/")) {
       if (!rawSeg.isEmpty()) {
         segmentCount++;

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
@@ -10,9 +10,14 @@ import java.util.regex.Pattern;
 final class RegBuilder {
   private final StringJoiner full = new StringJoiner("/");
   private final StringJoiner extract = new StringJoiner("/");
+  private final boolean ignoreTrailingSlashes;
   private boolean trailingSlash;
   private boolean multiSlash;
   private boolean literal = true;
+
+  public RegBuilder(boolean ignoreTrailingSlashes) {
+    this.ignoreTrailingSlashes = ignoreTrailingSlashes;
+  }
 
   void add(PathSegment pathSegment, List<String> paramNames) {
     full.add(pathSegment.asRegexString(false));
@@ -48,6 +53,11 @@ final class RegBuilder {
     if (trailingSlash) {
       parts += "\\/";
     }
+
+    if (!ignoreTrailingSlashes) {
+      return "^/" + parts;
+    }
+
     return "^/" + parts + "/?$";
   }
 

--- a/avaje-jex/src/test/java/io/avaje/jex/ShutDownTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/ShutDownTest.java
@@ -1,0 +1,25 @@
+package io.avaje.jex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ShutDownTest {
+
+  @Test
+  void shutDownHooks() {
+
+    List<String> results = new ArrayList<>();
+    var jex = Jex.create().config(c -> c.socketBacklog(0));
+    jex.lifecycle().onShutdown(() -> results.add("onShut"));
+    jex.lifecycle().registerShutdownHook(() -> results.add("onHook"));
+    var server = jex.start();
+
+    server.onShutdown(() -> results.add("serverShut"));
+    server.shutdown();
+    assertThat(results).hasSize(2); // 2 because jvm shutdown won't run in a junit
+  }
+}

--- a/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import io.avaje.jex.Jex;
 import io.avaje.jex.core.Constants;
 import io.avaje.jex.core.TestPair;
+import io.avaje.jex.http.ContentType;
 
 class CompressionTest {
 
@@ -27,7 +28,8 @@ class CompressionTest {
                     r.get(
                             "/compress",
                             ctx ->
-                                ctx.write(CompressionTest.class.getResourceAsStream("/64KB.json")))
+                                ctx.contentType(ContentType.APPLICATION_JSON)
+                                    .write(CompressionTest.class.getResourceAsStream("/64KB.json")))
                         .get(
                             "/sus",
                             ctx ->

--- a/avaje-jex/src/test/java/io/avaje/jex/http/TrailingSlashTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/http/TrailingSlashTest.java
@@ -1,0 +1,42 @@
+package io.avaje.jex.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jex.Jex;
+import io.avaje.jex.core.TestPair;
+
+class TrailingSlashTest {
+
+  static TestPair pair = init();
+
+  static TestPair init() {
+    final Jex app =
+        Jex.create()
+            .config(c -> c.socketBacklog(0).ignoreTrailingSlashes(false))
+            .get("/slash", ctx -> {});
+
+    return TestPair.create(app);
+  }
+
+  @AfterAll
+  static void end() {
+    pair.shutdown();
+  }
+
+  @Test
+  void get() {
+    HttpResponse<String> res = pair.request().path("slash/").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(404);
+  }
+
+  @Test
+  void getNoTrailing() {
+    HttpResponse<String> res = pair.request().path("slash").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(204);
+  }
+}

--- a/avaje-jex/src/test/java/io/avaje/jex/routes/PathParserTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/routes/PathParserTest.java
@@ -21,7 +21,7 @@ class PathParserTest {
 
     assertTrue(pathParser.matches("/one/1/"));
     assertTrue(pathParser.matches("/one/2/"));
-    assertTrue(pathParser.matches("/one/3//")); // accepts trailing double slash?
+    assertFalse(pathParser.matches("/one/3//")); // accepts trailing double slash?
     assertFalse(pathParser.matches("/one/3///")); // but not triple slash?
     assertFalse(pathParser.matches("/one/1"));
     assertFalse(pathParser.matches("/one/2"));


### PR DESCRIPTION
- now ignore trailing slashes behaves correctly
- fix put registering to get methods when using the jex convenience method