### PR TITLE
Support Jdk Filters

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
@@ -1,11 +1,15 @@
 package io.avaje.jex;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
+import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.spi.HttpServerProvider;
 
@@ -29,6 +33,7 @@ final class DJexConfig implements JexConfig {
   private int bufferInitial = 256;
   private long bufferMax = 4096L;
   private HttpServerProvider serverProvider;
+  private final List<Filter> jdkFilters = new ArrayList<>();
 
   @Override
   public JexConfig host(String host) {
@@ -128,6 +133,17 @@ final class DJexConfig implements JexConfig {
   @Override
   public boolean ignoreTrailingSlashes() {
     return ignoreTrailingSlashes;
+  }
+
+  @Override
+  public List<Filter> jdkFilters() {
+    return jdkFilters;
+  }
+
+  @Override
+  public JexConfig jdkFilters(Filter... filters) {
+    Collections.addAll(jdkFilters, filters);
+    return this;
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -1,15 +1,18 @@
 package io.avaje.jex;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
+import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.spi.HttpServerProvider;
 
 import io.avaje.jex.compression.CompressionConfig;
+import io.avaje.jex.http.HttpFilter;
 import io.avaje.jex.spi.JsonService;
 import io.avaje.jex.spi.TemplateRender;
 
@@ -109,6 +112,19 @@ public sealed interface JexConfig permits DJexConfig {
    */
   JexConfig initialStreamBufferSize(int initialSize);
 
+  /** The current jdk {@link Filter}s */
+  List<Filter> jdkFilters();
+
+  /**
+   * Adds jdk {@link Filter}s to the underlying HttpServer Context.
+   *
+   * <p>This is for compatibility with existing classes that implement {@link Filter} from the jdk. See {@link
+   * Routing#filter(HttpFilter)} for creating jex filters
+   *
+   * @param filters the filters to add to the underlying server
+   */
+  JexConfig jdkFilters(Filter... filters);
+
   /** Returns the configured JSON service. */
   JsonService jsonService();
 
@@ -185,5 +201,4 @@ public sealed interface JexConfig permits DJexConfig {
    *     default value is used
    */
   JexConfig socketBacklog(int backlog);
-
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
@@ -64,7 +64,7 @@ public final class BootstrapServer {
         server.setExecutor(config.executor());
       }
 
-      server.createContext(contextPath, handler);
+      server.createContext(contextPath, handler).getFilters().addAll(config.jdkFilters());
       server.start();
 
       jex.lifecycle().status(AppLifecycle.Status.STARTED);


### PR DESCRIPTION
It occurred to me while doing https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13243, that useful `com.sun.net.httpserver.Filter` implementations might already exist.

- adds configuration methods to add jdk filters to the underlying server