### PR TITLE
Create Jdk Filter Mapper

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/Routing.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Routing.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import com.sun.net.httpserver.Filter;
+
 import io.avaje.jex.http.Context;
 import io.avaje.jex.http.ExceptionHandler;
 import io.avaje.jex.http.ExchangeHandler;
@@ -122,6 +124,11 @@ public sealed interface Routing permits DefaultRouting {
 
   /** Add a filter for all matched requests. */
   Routing filter(HttpFilter handler);
+
+  /** Add a filter for all matched requests. */
+  default Routing filter(Filter handler) {
+    return filter(HttpFilter.fromJdkFilter(handler));
+  }
 
   /** Add a pre-processing filter for all matched requests. */
   default Routing before(Consumer<Context> handler) {

--- a/avaje-jex/src/main/java/io/avaje/jex/http/HttpFilter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/HttpFilter.java
@@ -1,5 +1,6 @@
 package io.avaje.jex.http;
 
+import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.HttpExchange;
 
 /**
@@ -51,5 +52,10 @@ public interface HttpFilter {
      * the application's {@linkplain HttpExchange exchange} handler will not be invoked.
      */
     void proceed();
+  }
+
+  static HttpFilter fromJdkFilter(Filter filter) {
+
+    return new JdkFilter(filter);
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/http/HttpFilter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/HttpFilter.java
@@ -54,6 +54,9 @@ public interface HttpFilter {
     void proceed();
   }
 
+  /**
+   * Convert the JDK Filter into a Jex HttpFilter.
+   */
   static HttpFilter fromJdkFilter(Filter filter) {
     return new JdkFilter(filter);
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/http/HttpFilter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/HttpFilter.java
@@ -55,7 +55,6 @@ public interface HttpFilter {
   }
 
   static HttpFilter fromJdkFilter(Filter filter) {
-
     return new JdkFilter(filter);
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/http/JdkFilter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/JdkFilter.java
@@ -11,8 +11,8 @@ final class JdkFilter implements HttpFilter {
 
   private final Filter delegate;
 
-  public JdkFilter(Filter delegateFilter) {
-    this.delegate = delegateFilter;
+  public JdkFilter(Filter delegate) {
+    this.delegate = delegate;
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/http/JdkFilter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/JdkFilter.java
@@ -1,0 +1,27 @@
+package io.avaje.jex.http;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import com.sun.net.httpserver.Filter;
+import com.sun.net.httpserver.Filter.Chain;
+
+final class JdkFilter implements HttpFilter {
+
+  private final Filter delegate;
+
+  public JdkFilter(Filter delegateFilter) {
+    this.delegate = delegateFilter;
+  }
+
+  @Override
+  public void filter(Context ctx, FilterChain chain) {
+
+    try {
+      delegate.doFilter(ctx.exchange(), new Chain(List.of(), ex -> chain.proceed()));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/avaje-jex/src/main/java/io/avaje/jex/http/JdkFilter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/JdkFilter.java
@@ -11,13 +11,12 @@ final class JdkFilter implements HttpFilter {
 
   private final Filter delegate;
 
-  public JdkFilter(Filter delegate) {
+  JdkFilter(Filter delegate) {
     this.delegate = delegate;
   }
 
   @Override
   public void filter(Context ctx, FilterChain chain) {
-
     try {
       delegate.doFilter(ctx.exchange(), new Chain(List.of(), ex -> chain.proceed()));
     } catch (IOException e) {

--- a/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.http.HttpResponse;
-import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 
 import org.junit.jupiter.api.AfterAll;

--- a/avaje-jex/src/test/java/io/avaje/jex/http/JdkFilterTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/http/JdkFilterTest.java
@@ -1,0 +1,119 @@
+package io.avaje.jex.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.Filter;
+
+import io.avaje.jex.Jex;
+import io.avaje.jex.core.TestPair;
+
+class JdkFilterTest {
+
+  static final TestPair pair = init();
+  static final AtomicReference<String> afterAll = new AtomicReference<>();
+  static final AtomicReference<String> afterTwo = new AtomicReference<>();
+
+  static TestPair init() {
+    final Jex app =
+        Jex.create()
+            .routing(
+                routing ->
+                    routing
+                        .get("/", ctx -> ctx.text("roo"))
+                        .get("/noResponse", ctx -> {})
+                        .get("/one", ctx -> ctx.text("one"))
+                        .get("/two", ctx -> ctx.text("two"))
+                        .get("/two/{id}", ctx -> ctx.text("two-id"))
+                        .filter(
+                            Filter.beforeHandler(
+                                "before", ex -> ex.getResponseHeaders().set("before-all", "set")))
+                        .filter(
+                            (ctx, chain) -> {
+                              if (ctx.path().contains("/two/")) {
+                                ctx.header("before-two", "set");
+                              }
+                              chain.proceed();
+                            })
+                        .filter(Filter.afterHandler("after", ex -> afterAll.set("set")))
+                        .filter(
+                            (ctx, chain) -> {
+                              chain.proceed();
+                              if (ctx.path().contains("/two/")) {
+                                afterTwo.set("set");
+                              }
+                            })
+                        .get("/dummy", ctx -> ctx.text("dummy")));
+
+    return TestPair.create(app);
+  }
+
+  @AfterAll
+  static void end() {
+    pair.shutdown();
+  }
+
+  void clearAfter() {
+    afterAll.set(null);
+    afterTwo.set(null);
+  }
+
+  @Test
+  void get() {
+    clearAfter();
+    HttpResponse<String> res = pair.request().GET().asString();
+    assertHasBeforeAfterAll(res);
+    assertNoBeforeAfterTwo(res);
+
+    clearAfter();
+    res = pair.request().path("one").GET().asString();
+    assertHasBeforeAfterAll(res);
+    assertNoBeforeAfterTwo(res);
+
+    clearAfter();
+    res = pair.request().path("two").GET().asString();
+    assertHasBeforeAfterAll(res);
+    assertNoBeforeAfterTwo(res);
+  }
+
+  @Test
+  void getNoResponse() {
+    clearAfter();
+    HttpResponse<String> res = pair.request().path("noResponse").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(204);
+    assertHasBeforeAfterAll(res);
+    assertNoBeforeAfterTwo(res);
+  }
+
+  @Test
+  void get_two_expect_extraFilters() {
+    clearAfter();
+    HttpResponse<String> res = pair.request().path("two/42").GET().asString();
+
+    final HttpHeaders headers = res.headers();
+    assertHasBeforeAfterAll(res);
+    assertThat(headers.firstValue("before-two")).get().isEqualTo("set");
+    assertThat(afterTwo.get()).isEqualTo("set");
+  }
+
+  private void assertNoBeforeAfterTwo(HttpResponse<String> res) {
+    assertThat(res.statusCode()).isLessThan(300);
+    assertThat(res.headers().firstValue("before-two")).isEmpty();
+    assertThat(afterTwo.get()).isNull();
+  }
+
+  private void assertHasBeforeAfterAll(HttpResponse<String> res) {
+    assertThat(res.statusCode()).isLessThan(300);
+    assertThat(res.headers().firstValue("before-all")).get().isEqualTo("set");
+    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(2));
+    assertThat(afterAll.get()).isEqualTo("set");
+  }
+}


### PR DESCRIPTION
Now can convert `com.sun.net.httpserver.Filter` implementations into Jex `HttpFilter`s

an alternative to #191 