### PR TITLE
Avoid sending headers twice on write error

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/ExceptionManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ExceptionManager.java
@@ -56,6 +56,12 @@ final class ExceptionManager {
   }
 
   private void defaultHandling(JdkContext ctx, HttpResponseException exception) {
+
+    //if already sent headers, can't send again
+    if (ctx.responseSent()) {
+      return;
+    }
+
     ctx.status(exception.status());
     var jsonResponse = exception.jsonResponse();
     if (exception.status() == HttpStatus.FOUND_302.status()) {


### PR DESCRIPTION
This prevents muddling the stacktrace with a (headers already sent exception )