### PR TITLE
Remove sealed from API - Jex, JexConfig, Routing, AppLifecycle

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/AppLifecycle.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/AppLifecycle.java
@@ -1,7 +1,7 @@
 package io.avaje.jex;
 
 /** Defines the lifecycle configuration for an application. */
-public sealed interface AppLifecycle permits DefaultLifecycle {
+public interface AppLifecycle {
 
   /** Represents the possible states of the application server. */
   enum Status {

--- a/avaje-jex/src/main/java/io/avaje/jex/Jex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Jex.java
@@ -30,7 +30,7 @@ import io.avaje.jex.spi.TemplateRender;
  *
  * }</pre>
  */
-public sealed interface Jex permits DJex {
+public interface Jex {
 
   /**
    * Create Jex.

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -20,7 +20,7 @@ import io.avaje.jex.spi.TemplateRender;
  * endpoint, trailing slash handling, JSON service, template renderers, executor service, HTTPS
  * configuration, compression, and plugin loading.
  */
-public sealed interface JexConfig permits DJexConfig {
+public interface JexConfig {
 
   /** Returns the configured compression settings. */
   CompressionConfig compression();

--- a/avaje-jex/src/main/java/io/avaje/jex/Routing.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Routing.java
@@ -16,7 +16,7 @@ import io.avaje.jex.http.sse.SseClient;
 import io.avaje.jex.security.Role;
 
 /** Routing abstraction. */
-public sealed interface Routing permits DefaultRouting {
+public interface Routing {
 
   /** Add the routes provided by the given HttpService. */
   Routing add(Routing.HttpService service);


### PR DESCRIPTION
We desire to not restrict these interfaces allowing users of the API to easily test interactions with this API if they desire to.