### PR TITLE
Fix startup log

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,6 @@ The JDK provides an SPI to swap the underlying `HttpServer`, so you can easily u
 
 <dependency>
   <groupId>org.eclipse.jetty</groupId>
-  <artifactId>jetty-server</artifactId>
-  <version>${jetty.version}</version>
-</dependency>
-
-<dependency>
-  <groupId>org.eclipse.jetty</groupId>
   <artifactId>jetty-http-spi</artifactId>
   <version>${jetty.version}</version>
 </dependency>

--- a/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
@@ -66,9 +66,15 @@ public final class BootstrapServer {
 
       server.createContext(contextPath, handler);
       server.start();
-
+      var actualAddress = server.getAddress();
       jex.lifecycle().status(AppLifecycle.Status.STARTED);
-      log.log(INFO, "Avaje Jex started {0} on port {1}://{2}", serverClass, scheme, socketAddress);
+      log.log(
+          INFO,
+          "Avaje Jex started {0} on port {1}://{2}:{3,number,#}",
+          serverClass,
+          scheme,
+          actualAddress.getHostName(),
+          actualAddress.getPort());
       log.log(DEBUG, routes);
       return new JdkJexServer(server, jex.lifecycle(), handler);
     } catch (IOException e) {

--- a/examples/example-http-generation/src/main/java/module-info.java
+++ b/examples/example-http-generation/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 open module example.http.generation {
 
+  requires io.avaje.config;
   requires io.avaje.jsonb;
   requires io.avaje.http.api;
   requires io.avaje.jex;

--- a/examples/example-jetty/pom.xml
+++ b/examples/example-jetty/pom.xml
@@ -9,19 +9,13 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-      <version>12.0.17</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-spi</artifactId>
       <version>12.0.17</version>
     </dependency>
+    
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jex</artifactId>
-      <version>3.0-RC20</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
noticed that you usually can't copy paste the current output `http://0.0.0.0/0.0.0.0:<port>`

with these changes:

for JDK server impl you usually get something like: 
`started class sun.net.httpserver.HttpServerImpl on port http://0:0:0:0:0:0:0:0:<port>`

for jetty you get
`started class org.eclipse.jetty.http.spi.JettyHttpServer on port http://0.0.0.0:<port>`

for robaho you get
`started class robaho.net.httpserver.HttpServerImpl on port http://0.0.0.0:<port>`
