### PR TITLE
Remove `fromJson(Class)`

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
@@ -70,7 +70,8 @@ public final class BootstrapServer {
       jex.lifecycle().status(AppLifecycle.Status.STARTED);
       log.log(
           INFO,
-          "Avaje Jex started {0} on port {1}://{2}:{3,number,#}",
+          "Avaje Jex {0} started {1} on {2}://{3}:{4,number,#}",
+          BootstrapServer.class.getPackage().getImplementationVersion(),
           serverClass,
           scheme,
           actualAddress.getHostName(),

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -133,11 +133,6 @@ final class JdkContext implements Context {
   }
 
   @Override
-  public <T> T bodyAsClass(Class<T> beanType) {
-    return mgr.fromJson(beanType, bodyAsInputStream());
-  }
-
-  @Override
   public InputStream bodyAsInputStream() {
     return exchange.getRequestBody();
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -71,10 +71,6 @@ final class ServiceManager {
     return jsonService;
   }
 
-  <T> T fromJson(Class<T> type, InputStream is) {
-    return jsonService.fromJson(type, is);
-  }
-
   <T> T fromJson(Type type, InputStream is) {
     return jsonService.fromJson(type, is);
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
@@ -34,15 +34,6 @@ public final class JacksonJsonService implements JsonService {
   }
 
   @Override
-  public <T> T fromJson(Class<T> type, InputStream is) {
-    try {
-      return mapper.readValue(is, type);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-  }
-
-  @Override
   public <T> T fromJson(Type type, InputStream is) {
     try {
       final var javaType =

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbJsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbJsonService.java
@@ -26,11 +26,6 @@ public final class JsonbJsonService implements JsonService {
   }
 
   @Override
-  public <T> T fromJson(Class<T> clazz, InputStream is) {
-    return jsonb.type(clazz).fromJson(is);
-  }
-
-  @Override
   public <T> T fromJson(Type clazz, InputStream is) {
     return jsonb.<T>type(clazz).fromJson(is);
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
@@ -72,7 +72,9 @@ public interface Context {
    *
    * @param beanType The bean type
    */
-  <T> T bodyAsClass(Class<T> beanType);
+  default <T> T bodyAsClass(Class<T> beanType) {
+    return bodyAsType(beanType);
+  }
 
   /**
    * Returns the request body as an input stream.

--- a/avaje-jex/src/main/java/io/avaje/jex/spi/JsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/spi/JsonService.java
@@ -40,20 +40,6 @@ public non-sealed interface JsonService extends JexExtension {
    * <p>Reads a JSON-formatted input stream and deserializes it into a Java object of the specified
    * type.
    *
-   * @param type the Class object of the desired type
-   * @param is the input stream containing the JSON data
-   * @return the deserialized object
-   */
-  default <T> T fromJson(Class<T> type, InputStream is) {
-    return fromJson((Type) type, is);
-  }
-
-  /**
-   * **Reads JSON from an InputStream**
-   *
-   * <p>Reads a JSON-formatted input stream and deserializes it into a Java object of the specified
-   * type.
-   *
    * @param type the Type object of the desired type
    * @param is the input stream containing the JSON data
    * @return the deserialized object

--- a/avaje-jex/src/main/java/io/avaje/jex/spi/JsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/spi/JsonService.java
@@ -44,7 +44,9 @@ public non-sealed interface JsonService extends JexExtension {
    * @param is the input stream containing the JSON data
    * @return the deserialized object
    */
-  <T> T fromJson(Class<T> type, InputStream is);
+  default <T> T fromJson(Class<T> type, InputStream is) {
+    return fromJson((Type) type, is);
+  }
 
   /**
    * **Reads JSON from an InputStream**


### PR DESCRIPTION
JsonService is mainly used internally, so there isn't much of a reason to have a `fromJson(Class)`