### PR TITLE
Remove flush from JsonOutput

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
@@ -58,15 +58,13 @@ public final class JacksonJsonService implements JsonService {
   @Override
   public void toJson(Object bean, OutputStream os) {
     try {
-      try (JsonGenerator generator = mapper.createGenerator(os)) {
+      try (var generator = mapper.createGenerator(os)) {
         // only flush to underlying OutputStream on success
         generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
         generator.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
         generator.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
         mapper.writeValue(generator, bean);
-        generator.flush();
       }
-      os.flush();
       os.close();
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -84,17 +82,10 @@ public final class JacksonJsonService implements JsonService {
 
   @Override
   public <T> void toJsonStream(Iterator<T> iterator, OutputStream os) {
-    final JsonGenerator generator;
-    try {
-      generator = mapper.createGenerator(os);
+    try (var generator = mapper.createGenerator(os)) {
       generator.setPrettyPrinter(null);
-      try {
-        while (iterator.hasNext()) {
-          write(iterator, generator);
-        }
-      } finally {
-        generator.flush();
-        generator.close();
+      while (iterator.hasNext()) {
+        write(iterator, generator);
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbJsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbJsonService.java
@@ -37,7 +37,7 @@ public final class JsonbJsonService implements JsonService {
 
   @Override
   public void toJson(Object bean, OutputStream os) {
-    jsonb.toJson(bean, os);
+    jsonb.toJson(bean, new NoFlushJsonOutput(os));
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbOutput.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbOutput.java
@@ -1,10 +1,10 @@
 package io.avaje.jex.core.json;
 
-import io.avaje.jex.http.Context;
-import io.avaje.json.stream.JsonOutput;
-
 import java.io.IOException;
 import java.io.OutputStream;
+
+import io.avaje.jex.http.Context;
+import io.avaje.json.stream.JsonOutput;
 
 /**
  * avaje-jsonb output that allows for writing fixed length content
@@ -43,10 +43,8 @@ public final class JsonbOutput implements JsonOutput {
   }
 
   @Override
-  public void flush() throws IOException {
-    if (os != null) {
-      os.flush();
-    }
+  public void flush() {
+    // shouldn't manually flush
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/NoFlushJsonOutput.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/NoFlushJsonOutput.java
@@ -1,0 +1,35 @@
+package io.avaje.jex.core.json;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import io.avaje.json.stream.JsonOutput;
+
+final class NoFlushJsonOutput implements JsonOutput {
+
+  private final OutputStream outputStream;
+
+  NoFlushJsonOutput(OutputStream outputStream) {
+    this.outputStream = outputStream;
+  }
+
+  @Override
+  public void write(byte[] content, int offset, int length) throws IOException {
+    outputStream.write(content, offset, length);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    // no flush
+  }
+
+  @Override
+  public void close() throws IOException {
+    outputStream.close();
+  }
+
+  @Override
+  public OutputStream unwrapOutputStream() {
+    return outputStream;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.proc>full</maven.compiler.proc>
     <avaje.config.version>4.0</avaje.config.version>
     <avaje.inject.version>11.2</avaje.inject.version>
-    <avaje.jsonb.version>3.0</avaje.jsonb.version>
+    <avaje.jsonb.version>3.1-RC2</avaje.jsonb.version>
     <avaje.http.version>3.0</avaje.http.version>
     <avaje.metrics.version>9.4</avaje.metrics.version>
     <avaje.validator.version>2.8</avaje.validator.version>


### PR DESCRIPTION
flush() should only be used when you have a long lived push type/events endpoint.