### PR TITLE
Cache `bodyAsBytes` result

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -75,8 +75,8 @@ final class ServiceManager {
     return jsonService.fromJson(type, is);
   }
 
-  <T> T fromJson(Type type, byte[] is) {
-    return jsonService.fromJson(type, is);
+  <T> T fromJson(Type type, byte[] data) {
+    return jsonService.fromJson(type, data);
   }
 
   void toJson(Object bean, OutputStream os) {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -75,6 +75,10 @@ final class ServiceManager {
     return jsonService.fromJson(type, is);
   }
 
+  <T> T fromJson(Type type, byte[] is) {
+    return jsonService.fromJson(type, is);
+  }
+
   void toJson(Object bean, OutputStream os) {
     jsonService.toJson(bean, os);
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
@@ -24,8 +24,7 @@ public final class JacksonJsonService implements JsonService {
 
   /** Create with defaults for Jackson */
   public JacksonJsonService() {
-    this.mapper =
-      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    this.mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }
 
   /** Create with a Jackson instance that might have custom configuration. */
@@ -36,10 +35,7 @@ public final class JacksonJsonService implements JsonService {
   @Override
   public <T> T fromJson(Type type, InputStream is) {
     try {
-      final var javaType =
-        javaTypes.computeIfAbsent(
-          type.getTypeName(), k -> mapper.getTypeFactory().constructType(type));
-
+      final var javaType = javaType(type);
       return mapper.readValue(is, javaType);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -49,14 +45,15 @@ public final class JacksonJsonService implements JsonService {
   @Override
   public <T> T fromJson(Type type, byte[] data) {
     try {
-      final var javaType =
-          javaTypes.computeIfAbsent(
-              type.getTypeName(), k -> mapper.getTypeFactory().constructType(type));
-
+      final var javaType = javaType(type);
       return mapper.readValue(data, javaType);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  private JavaType javaType(Type type) {
+    return javaTypes.computeIfAbsent(type.getTypeName(), k -> mapper.getTypeFactory().constructType(type));
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JacksonJsonService.java
@@ -47,6 +47,19 @@ public final class JacksonJsonService implements JsonService {
   }
 
   @Override
+  public <T> T fromJson(Type type, byte[] data) {
+    try {
+      final var javaType =
+          javaTypes.computeIfAbsent(
+              type.getTypeName(), k -> mapper.getTypeFactory().constructType(type));
+
+      return mapper.readValue(data, javaType);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
   public void toJson(Object bean, OutputStream os) {
     try {
       try (var generator = mapper.createGenerator(os)) {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbJsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/json/JsonbJsonService.java
@@ -31,6 +31,11 @@ public final class JsonbJsonService implements JsonService {
   }
 
   @Override
+  public <T> T fromJson(Type clazz, byte[] data) {
+    return jsonb.<T>type(clazz).fromJson(data);
+  }
+
+  @Override
   public void toJson(Object bean, OutputStream os) {
     jsonb.toJson(bean, new NoFlushJsonOutput(os));
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
@@ -80,6 +80,7 @@ public interface Context {
    * Returns the request body as an input stream.
    *
    * @return The request body as an input stream.
+   * @implNote will return an empty stream if any of the various body methods were called
    */
   InputStream bodyAsInputStream();
 
@@ -89,6 +90,22 @@ public interface Context {
    * @param beanType The bean type
    */
   <T> T bodyAsType(Type beanType);
+  
+  /**
+   * Return the request body as bean using {@link #bodyAsInputStream()}.
+   *
+   * @param beanType The bean type
+   */
+  default <T> T bodyStreamAsClass(Class<T> beanType) {
+    return bodyAsType(beanType);
+  }
+  
+  /**
+   * Return the request body as bean of the given type using {@link #bodyAsInputStream()}.
+   *
+   * @param beanType The bean type
+   */
+  <T> T bodyStreamAsType(Type beanType);
 
   /** Return the request content length. */
   long contentLength();

--- a/avaje-jex/src/main/java/io/avaje/jex/spi/JsonService.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/spi/JsonService.java
@@ -35,16 +35,22 @@ public non-sealed interface JsonService extends JexExtension {
   String toJsonString(Object bean);
 
   /**
-   * **Reads JSON from an InputStream**
-   *
-   * <p>Reads a JSON-formatted input stream and deserializes it into a Java object of the specified
-   * type.
+   * Deserializes a json input stream and deserializes it into a Java object of the specified type.
    *
    * @param type the Type object of the desired type
    * @param is the input stream containing the JSON data
    * @return the deserialized object
    */
   <T> T fromJson(Type type, InputStream is);
+
+  /**
+   * Deserializes a json byte[] into a Java object of the specified type.
+   *
+   * @param type the Type object of the desired type
+   * @param data the byte[] containing the JSON data
+   * @return the deserialized object
+   */
+  <T> T fromJson(Type type, byte[] data);
 
   /**
    * Serializes a stream of Java objects into a JSON-Stream format, using the {@code x-json-stream}

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextTest.java
@@ -137,7 +137,7 @@ class ContextTest {
 
   @Test
   void post_double_json_fail() {
-    HttpResponse<String> res = pair.request().path("doubleJsonStreamFail").body("{}").POST().asString();
+    HttpResponse<String> res = pair.request().path("doubleJsonStream").body("{}").POST().asString();
     assertThat(res.body()).isEqualTo("Internal Server Error");
   }
 

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextTest.java
@@ -1,14 +1,16 @@
 package io.avaje.jex.core;
 
-import io.avaje.jex.Jex;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.Optional;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
-import java.net.http.HttpResponse;
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static org.assertj.core.api.Assertions.assertThat;
+import io.avaje.jex.Jex;
 
 class ContextTest {
 
@@ -38,6 +40,15 @@ class ContextTest {
         .post("/echo", ctx -> ctx.text("req-body[" + ctx.body() + "]"))
         .get("/{a}/{b}", ctx -> ctx.text("ze-get-" + ctx.pathParamMap()))
         .post("/{a}/{b}", ctx -> ctx.text("ze-post-" + ctx.pathParamMap()))
+        .post("/doubleJsonStream", ctx -> {
+            ctx.bodyAsInputStream().readAllBytes();
+            ctx.text(ctx.bodyAsClass(Map.class)+"");
+          })
+        .post("/doubleJsonStreamBytes", ctx -> {
+            ctx.body();
+            ctx.text(ctx.bodyAsClass(Map.class)+"");
+          })
+        .post("/doubleString", ctx -> ctx.text(ctx.body() + ctx.body()))
         .get("/status", ctx -> {
           ctx.status(201);
           ctx.text("status:" + ctx.status());
@@ -119,9 +130,27 @@ class ContextTest {
   }
 
   @Test
-  void post_body() {
+  void post_double_string() {
     HttpResponse<String> res = pair.request().path("echo").body("simple").POST().asString();
     assertThat(res.body()).isEqualTo("req-body[simple]");
+  }
+
+  @Test
+  void post_double_json_fail() {
+    HttpResponse<String> res = pair.request().path("doubleJsonStreamFail").body("{}").POST().asString();
+    assertThat(res.body()).isEqualTo("Internal Server Error");
+  }
+
+  @Test
+  void post_double_json_bytes() {
+    HttpResponse<String> res = pair.request().path("doubleJsonStreamBytes").body("{}").POST().asString();
+    assertThat(res.body()).isEqualTo("{}");
+  }
+
+  @Test
+  void post_body() {
+    HttpResponse<String> res = pair.request().path("doubleString").body("simple").POST().asString();
+    assertThat(res.body()).isEqualTo("simplesimple");
   }
 
   @Test


### PR DESCRIPTION
As we know, reading the request `InputStream` makes it so the stream cannot be read again. This means that filters cannot use the request body else the handler will be unable to read it.

- now json bodyAsType uses bodyAsBytes
- bodyAsBytes will cache the bytes in the request context
- add bodyStreamAs json methods