### PR TITLE
Add multivalue header methods

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/compression/CompressedOutputStream.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/compression/CompressedOutputStream.java
@@ -2,7 +2,7 @@ package io.avaje.jex.compression;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -39,7 +39,7 @@ public final class CompressedOutputStream extends OutputStream {
 
       if (compressionAllowed && length >= minSizeForCompression) {
         Optional<Compressor> compressor;
-        compressor = findMatchingCompressor(ctx.header(Constants.ACCEPT_ENCODING));
+        compressor = findMatchingCompressor(ctx.headerValues(Constants.ACCEPT_ENCODING));
         if (compressor.isPresent()) {
           this.compressedStream = compressor.get().compress(originStream);
           ctx.header(Constants.CONTENT_ENCODING, compressor.get().encoding());
@@ -69,9 +69,9 @@ public final class CompressedOutputStream extends OutputStream {
     originStream.close();
   }
 
-  private Optional<Compressor> findMatchingCompressor(String acceptedEncoding) {
-    if (acceptedEncoding != null) {
-      return Arrays.stream(acceptedEncoding.split(","))
+  private Optional<Compressor> findMatchingCompressor(List<String> list) {
+    if (list != null) {
+      return list.stream()
           .map(e -> e.trim().split(";")[0])
           .map(e -> "*".equals(e) ? "gzip" : e.toLowerCase())
           .map(compression::forType)

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -221,13 +221,17 @@ final class JdkContext implements Context {
   }
 
   private String header(Headers headers, String name) {
-    final List<String> values = headers.get(name);
-    return values == null || values.isEmpty() ? null : values.getFirst();
+    return headers.getFirst(name);
   }
 
   @Override
   public String header(String key) {
     return header(exchange.getRequestHeaders(), key);
+  }
+
+  @Override
+  public List<String> headerValues(String key) {
+    return exchange.getRequestHeaders().get(key);
   }
 
   @Override
@@ -261,8 +265,18 @@ final class JdkContext implements Context {
   }
 
   @Override
-  public Headers headers() {
+  public Headers requestHeaders() {
     return exchange.getRequestHeaders();
+  }
+
+  @Override
+  public Headers responseHeaders() {
+    return exchange.getResponseHeaders();
+  }
+
+  @Override
+  public List<String> responseHeaderValues(String key) {
+    return exchange.getResponseHeaders().get(key);
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
@@ -90,7 +90,7 @@ public interface Context {
    * @param beanType The bean type
    */
   <T> T bodyAsType(Type beanType);
-  
+
   /**
    * Return the request body as bean using {@link #bodyAsInputStream()}.
    *
@@ -99,7 +99,7 @@ public interface Context {
   default <T> T bodyStreamAsClass(Class<T> beanType) {
     return bodyAsType(beanType);
   }
-  
+
   /**
    * Return the request body as bean of the given type using {@link #bodyAsInputStream()}.
    *
@@ -192,11 +192,18 @@ public interface Context {
   }
 
   /**
-   * Return the request header.
+   * Return the request header value by name.
    *
-   * @param key The header key
+   * @param key The first value of the header
    */
   String header(String key);
+
+  /**
+   * Return the request headers.
+   *
+   * @param key all values of the header key
+   */
+  List<String> headerValues(String key);
 
   /**
    * Set the response header.
@@ -235,7 +242,14 @@ public interface Context {
    *
    * @return the request headers
    */
-  Headers headers();
+  Headers requestHeaders();
+
+  /**
+   * Return underlying response headers.
+   *
+   * @return the response headers
+   */
+  Headers responseHeaders();
 
   /** Add the response headers using the provided map. */
   default Context headers(Map<String, String> headers) {
@@ -438,6 +452,14 @@ public interface Context {
    * @return The value of the header, or null if not found.
    */
   String responseHeader(String key);
+
+  /**
+   * Returns the value of the specified response header.
+   *
+   * @param key The name of the header.
+   * @return The value of the header, or null if not found.
+   */
+  List<String> responseHeaderValues(String key);
 
   /** Return true if the response has been sent. */
   boolean responseSent();

--- a/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
@@ -33,10 +33,7 @@ class CompressionTest {
                             "/sus",
                             ctx ->
                                 ctx.write(
-                                    CompressionTest.class.getResourceAsStream("/public/sus.txt")))
-                        .get(
-                            "/forced",
-                            ctx -> ctx.header(Constants.CONTENT_ENCODING, "gzip").text("hi")));
+                                    CompressionTest.class.getResourceAsStream("/public/sus.txt"))));
 
     return TestPair.create(app);
   }
@@ -71,13 +68,5 @@ class CompressionTest {
         pair.request().header(Constants.ACCEPT_ENCODING, "gzip").path("sus").GET().asString();
     assertThat(res.statusCode()).isEqualTo(200);
     assertThat(res.headers().firstValue(Constants.CONTENT_ENCODING)).isEmpty();
-  }
-
-  @Test
-  void testForcedCompression() {
-    HttpResponse<String> res =
-        pair.request().header(Constants.ACCEPT_ENCODING, "gzip").path("forced").GET().asString();
-    assertThat(res.statusCode()).isEqualTo(200);
-    assertThat(res.headers().firstValue(Constants.CONTENT_ENCODING)).contains("gzip");
   }
 }

--- a/avaje-jex/src/test/java/io/avaje/jex/core/JsonTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/JsonTest.java
@@ -133,7 +133,7 @@ public class JsonTest {
       .as(HelloDto.class);
 
     assertThat(hres.statusCode()).isEqualTo(200);
-    final HttpHeaders headers = hres.headers();
+    final HttpHeaders headers = hres.requestHeaders();
     assertThat(headers.firstValue("Content-Type").orElseThrow()).isEqualTo("application/json");
 
     var bean = hres.body();

--- a/avaje-jex/src/test/java/io/avaje/jex/core/TestPair.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/TestPair.java
@@ -1,6 +1,7 @@
 package io.avaje.jex.core;
 
 import java.net.http.HttpClient.Version;
+import java.time.Duration;
 
 import io.avaje.http.client.HttpClient;
 import io.avaje.http.client.HttpClientRequest;
@@ -43,7 +44,12 @@ public class TestPair {
     var jexServer = app.port(0).start();
     var port = jexServer.port();
     var url = "http://localhost:" + port;
-    var client = HttpClient.builder().version(Version.HTTP_1_1).baseUrl(url).build();
+    var client =
+        HttpClient.builder()
+            .version(Version.HTTP_1_1)
+            .requestTimeout(Duration.ofDays(1))
+            .baseUrl(url)
+            .build();
 
     return new TestPair(port, jexServer, client);
   }


### PR DESCRIPTION
- add multi-value header methods
- make compressor use the new multi-value headers 

Also, it turns out jetty discards multi-value response headers so cookies don't really work. I got a [PR](https://github.com/jetty/jetty.project/pull/12929) there to fix.