### PR TITLE
Fix `fullUrl` on jetty

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
@@ -90,7 +90,7 @@ public interface Context {
    * @param beanType The bean type
    */
   <T> T bodyAsType(Type beanType);
-  
+
   /**
    * Return the request body as bean using {@link #bodyAsInputStream()}.
    *
@@ -99,7 +99,7 @@ public interface Context {
   default <T> T bodyStreamAsClass(Class<T> beanType) {
     return bodyAsType(beanType);
   }
-  
+
   /**
    * Return the request body as bean of the given type using {@link #bodyAsInputStream()}.
    *
@@ -188,7 +188,10 @@ public interface Context {
 
   /** Return the full request url, including query string (if present) */
   default String fullUrl() {
-    return scheme() + "://" + host() + uri().toString();
+
+    var uri = uri().toString();
+
+    return !uri.startsWith("/") ? uri : scheme() + "://" + host() + uri;
   }
 
   /**

--- a/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
@@ -188,9 +188,7 @@ public interface Context {
 
   /** Return the full request url, including query string (if present) */
   default String fullUrl() {
-
     var uri = uri().toString();
-
     return !uri.startsWith("/") ? uri : scheme() + "://" + host() + uri;
   }
 

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextLengthTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextLengthTest.java
@@ -1,12 +1,13 @@
 package io.avaje.jex.core;
 
-import io.avaje.jex.Jex;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.http.HttpResponse;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jex.Jex;
 
 class ContextLengthTest {
 
@@ -59,7 +60,7 @@ class ContextLengthTest {
       .GET().asString();
 
     assertThat(res.statusCode()).isEqualTo(200);
-    assertThat(res.body()).isEqualTo("uri:/uri/uriTest?a=av");
+    assertThat(res.body()).contains("/uri/uriTest?a=av");
   }
 
   @Test


### PR DESCRIPTION
it seems that jetty already gives the full URL so we were getting test failures like 

```
expected: "uri:/uri/uriTest?a=av"
 but was: "uri:http://localhost:57963/uri/uriTest?a=av"
```