### PR TITLE
Use `charAt` instead off startsWith where applicable

### DIFF
--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticResourceHandlerBuilder.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticResourceHandlerBuilder.java
@@ -127,7 +127,7 @@ final class StaticResourceHandlerBuilder implements StaticContent.Builder, Stati
   }
 
   private String prependSlash(String s) {
-    return s.startsWith("/") ? s : "/" + s;
+    return s.charAt(0) == '/' ? s : "/" + s;
   }
 
   private String appendSlash(String s) {

--- a/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
@@ -48,7 +48,7 @@ final class DJexConfig implements JexConfig {
 
       this.contextPath =
           contextPath
-              .transform(s -> s.startsWith("/") ? s : "/" + s)
+              .transform(s -> s.charAt(0) == '/' ? s : "/" + s)
               .transform(s -> s.endsWith("/") ? s.substring(0, s.lastIndexOf("/")) : s);
     }
     return this;

--- a/avaje-jex/src/main/java/io/avaje/jex/DefaultRouting.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DefaultRouting.java
@@ -37,11 +37,11 @@ final class DefaultRouting implements Routing {
   }
 
   private String path(String path) {
-    return String.join("", pathDeque) + ((path.startsWith("/") || path.isEmpty()) ? path : "/" + path);
+    return String.join("", pathDeque) + (path.charAt(0) == '/' || path.isEmpty() ? path : "/" + path);
   }
 
   private void addEndpoints(String path, HttpService group) {
-    path = path.startsWith("/") ? path : "/" + path;
+    path = path.charAt(0) == '/' ? path : "/" + path;
     pathDeque.addLast(path);
     group.add(this);
     pathDeque.removeLast();

--- a/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/Context.java
@@ -189,7 +189,7 @@ public interface Context {
   /** Return the full request url, including query string (if present) */
   default String fullUrl() {
     var uri = uri().toString();
-    return !uri.startsWith("/") ? uri : scheme() + "://" + host() + uri;
+    return uri.charAt(0) != '/' ? uri : scheme() + "://" + host() + uri;
   }
 
   /**

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathSegmentParser.java
@@ -69,9 +69,9 @@ final class PathSegmentParser {
   private PathSegment tokenSegment(String token) {
     if ("*".equals(token)) {
       return WILDCARD;
-    } else if (token.startsWith("<")) {
+    } else if (token.charAt(0) == '<') {
       return slashAccepting(token);
-    } else if (token.startsWith("{")) {
+    } else if (token.charAt(0) == '{') {
       return slashIgnoring(token);
     } else {
       return new PathSegment.Literal(token);


### PR DESCRIPTION
if you're checking whether a single character is in front of the string `charAt` is more efficient.