### PR TITLE
Support Range Requests

### DIFF
--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticClassResourceHandler.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticClassResourceHandler.java
@@ -93,7 +93,7 @@ final class StaticClassResourceHandler extends AbstractStaticHandler {
         addCachedEntry(ctx, urlPath, fis);
         return;
       }
-      ctx.write(fis);
+      ctx.rangedWrite(fis);
     } catch (final Exception e) {
       throw404(ctx.exchange());
     }

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticFileHandler.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticFileHandler.java
@@ -108,7 +108,7 @@ final class StaticFileHandler extends AbstractStaticHandler {
         addCachedEntry(ctx, urlPath, fis);
         return;
       }
-      ctx.write(fis);
+      ctx.rangedWrite(fis);
     } catch (FileNotFoundException e) {
       throw404(jdkExchange);
     }

--- a/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
@@ -28,6 +28,7 @@ final class DJexConfig implements JexConfig {
   private final CompressionConfig compression = new CompressionConfig();
   private int bufferInitial = 256;
   private long bufferMax = 4096L;
+  private int rangeChunkSize = 131_072;
   private HttpServerProvider serverProvider;
 
   @Override
@@ -197,6 +198,17 @@ final class DJexConfig implements JexConfig {
   @Override
   public JexConfig serverProvider(HttpServerProvider serverProvider) {
     this.serverProvider = serverProvider;
+    return this;
+  }
+
+  @Override
+  public int rangeChunkSize() {
+    return rangeChunkSize;
+  }
+
+  @Override
+  public JexConfig rangeChunkSize(int rangeChunkSize) {
+    this.rangeChunkSize = rangeChunkSize;
     return this;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -146,6 +146,17 @@ public interface JexConfig {
    */
   JexConfig port(int port);
 
+  /** The configured rangeChunk size */
+  int rangeChunkSize();
+
+  /**
+   * Set the chunk size on range requests, set to a high number to reduce the amount of range
+   * requests (especially for video streaming)
+   *
+   * @param rangeChunkSize chunk size on range requests
+   */
+  JexConfig rangeChunkSize(int rangeChunkSize);
+
   /**
    * Registers a template renderer for a specific file extension.
    *
@@ -185,5 +196,4 @@ public interface JexConfig {
    *     default value is used
    */
   JexConfig socketBacklog(int backlog);
-
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/compression/CompressedOutputStream.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/compression/CompressedOutputStream.java
@@ -36,6 +36,7 @@ public final class CompressedOutputStream extends OutputStream {
     if (!compressionDecided) {
       boolean compressionAllowed =
           compressedStream == null
+              && ctx.responseHeader(Constants.CONTENT_RANGE) == null
               && compression.allowsForCompression(ctx.responseHeader(Constants.CONTENT_TYPE));
 
       if (compressionAllowed && length >= minSizeForCompression) {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/Constants.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/Constants.java
@@ -19,4 +19,9 @@ public final class Constants {
   public static final String TEXT_PLAIN_UTF8 = "text/plain;charset=utf-8";
   public static final String APPLICATION_JSON = "application/json";
   public static final String APPLICATION_X_JSON_STREAM = "application/x-json-stream";
+
+  // range
+  public static final String ACCEPT_RANGES = "Accept-ranges";
+  public static final String RANGE = "Range";
+  public static final String CONTENT_RANGE = "Content-range";
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -536,4 +536,9 @@ final class JdkContext implements Context {
   public JsonService jsonService() {
     return mgr.jsonService();
   }
+
+  @Override
+  public void rangedWrite(InputStream inputStream, long totalBytes) {
+    mgr.writeRange(this, inputStream, totalBytes);
+  }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/RangeWriter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/RangeWriter.java
@@ -1,0 +1,86 @@
+package io.avaje.jex.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
+
+import io.avaje.jex.http.Context;
+import io.avaje.jex.http.HttpStatus;
+
+class RangeWriter {
+
+  private static final int DEFAULT_BUFFER_SIZE = 16384;
+
+  static void write(Context ctx, InputStream inputStream, long totalBytes, long chunkSize) {
+
+    ctx.header(Constants.ACCEPT_RANGES, "bytes");
+    final String rangeHeader = ctx.header(Constants.RANGE);
+    if (rangeHeader == null) {
+      ctx.contentLength(totalBytes).write(inputStream);
+      return;
+    }
+    final List<String> requestedRange =
+        Arrays.stream(rangeHeader.split("=")[1].split("-")).filter(s -> !s.isEmpty()).toList();
+    final long from = Long.parseLong(requestedRange.get(0));
+    final long to;
+
+    final boolean audioOrVideo = isAudioOrVideo(ctx.responseHeader(Constants.CONTENT_TYPE));
+
+    if (!audioOrVideo || from + chunkSize > totalBytes) {
+      to = totalBytes - 1; // chunk bigger than file, write all
+    } else if (requestedRange.size() == 2) {
+      to = Long.parseLong(requestedRange.get(1)); // chunk smaller than file, to/from specified
+    } else {
+      to = from + chunkSize - 1;
+    }
+
+    long contentLength;
+    if (audioOrVideo) {
+      contentLength = Math.min(to - from + 1, totalBytes);
+    } else {
+      contentLength = totalBytes - from;
+    }
+
+    final HttpStatus status;
+    if (audioOrVideo) {
+      status = HttpStatus.PARTIAL_CONTENT_206;
+    } else {
+      status = HttpStatus.OK_200;
+    }
+
+    ctx.status(status);
+    ctx.header(Constants.ACCEPT_RANGES, "bytes");
+    ctx.header(Constants.CONTENT_RANGE, "bytes " + from + "-" + to + "/" + totalBytes);
+    ctx.contentLength(contentLength);
+    try (var os = ctx.outputStream()) {
+      write(os, inputStream, from, to);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static void write(OutputStream outputStream, InputStream inputStream, long from, long to)
+      throws IOException {
+    byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+    long toSkip = from;
+    while (toSkip > 0) {
+      toSkip -= inputStream.skip(toSkip);
+    }
+    long bytesLeft = to - from + 1;
+    while (bytesLeft > 0) {
+      int read = inputStream.read(buffer, 0, (int) Math.min(DEFAULT_BUFFER_SIZE, bytesLeft));
+      if (read == -1) {
+        break; // End of stream reached unexpectedly
+      }
+      outputStream.write(buffer, 0, read);
+      bytesLeft -= read;
+    }
+  }
+
+  private static boolean isAudioOrVideo(String contentType) {
+    return contentType.startsWith("audio/") || contentType.startsWith("video/");
+  }
+}

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -37,6 +37,7 @@ final class ServiceManager {
   private final String scheme;
   private final int bufferInitial;
   private final long bufferMax;
+  private final int rangeChunks;
 
   static ServiceManager create(Jex jex) {
     return new Builder(jex).build();
@@ -49,7 +50,8 @@ final class ServiceManager {
       TemplateManager templateManager,
       String scheme,
       long bufferMax,
-      int bufferInitial) {
+      int bufferInitial,
+      int rangeChunks) {
     this.compressionConfig = compressionConfig;
     this.jsonService = jsonService;
     this.exceptionHandler = manager;
@@ -57,6 +59,7 @@ final class ServiceManager {
     this.scheme = scheme;
     this.bufferInitial = bufferInitial;
     this.bufferMax = bufferMax;
+    this.rangeChunks = rangeChunks;
   }
 
   OutputStream createOutputStream(JdkContext jdkContext) {
@@ -95,6 +98,10 @@ final class ServiceManager {
     } finally {
       maybeClose(iterator);
     }
+  }
+
+  void writeRange(Context ctx, InputStream is, long totalBytes) {
+    RangeWriter.write(ctx, is, totalBytes, rangeChunks);
   }
 
   void maybeClose(Object iterator) {
@@ -177,7 +184,8 @@ final class ServiceManager {
           initTemplateMgr(),
           jex.config().scheme(),
           jex.config().maxStreamBufferSize(),
-          jex.config().initialStreamBufferSize());
+          jex.config().initialStreamBufferSize(),
+          jex.config().rangeChunkSize());
     }
 
     JsonService initJsonService() {

--- a/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/compression/CompressionTest.java
@@ -69,4 +69,23 @@ class CompressionTest {
     assertThat(res.statusCode()).isEqualTo(200);
     assertThat(res.headers().firstValue(Constants.CONTENT_ENCODING)).isEmpty();
   }
+
+  @Test
+  void testCompressionRange() throws IOException {
+    var res =
+        pair.request()
+            .header(Constants.ACCEPT_ENCODING, "deflate, gzip;q=1.0, *;q=0.5")
+            .path("compress")
+            .GET()
+            .asInputStream();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.headers().firstValue(Constants.CONTENT_ENCODING)).contains("gzip");
+
+    var expected = CompressionTest.class.getResourceAsStream("/64KB.json").readAllBytes();
+
+    final var gzipInputStream = new GZIPInputStream(res.body());
+    var decompressed = gzipInputStream.readAllBytes();
+    gzipInputStream.close();
+    assertThat(decompressed).isEqualTo(expected);
+  }
 }

--- a/avaje-jex/src/test/java/io/avaje/jex/http/LargeSeekableInput.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/http/LargeSeekableInput.java
@@ -1,0 +1,57 @@
+package io.avaje.jex.http;
+
+import java.io.InputStream;
+
+class LargeSeekableInput extends InputStream {
+    private final long prefixSize;
+    private final long contentSize;
+    private long alreadyRead = 0L;
+
+    public LargeSeekableInput(long prefixSize, long contentSize) {
+        this.prefixSize = prefixSize;
+        this.contentSize = contentSize;
+    }
+
+    private long remaining() {
+        return prefixSize + contentSize - alreadyRead;
+    }
+
+    @Override
+    public int available() {
+        long rem = remaining();
+        if (rem >= 0 && rem <= Integer.MAX_VALUE) {
+            return (int) rem;
+        } else {
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    @Override
+    public long skip(long toSkip) {
+        if (toSkip <= 0) {
+            return 0;
+        } else {
+            long rem = remaining();
+            if (rem >= 0 && rem <= toSkip) {
+                alreadyRead += rem;
+                return rem;
+            } else {
+                alreadyRead += toSkip;
+                return toSkip;
+            }
+        }
+    }
+
+    @Override
+    public int read() {
+        if (remaining() == 0L) {
+            return -1;
+        } else if (alreadyRead < prefixSize) {
+            alreadyRead++;
+            return ' ';
+        } else {
+            alreadyRead++;
+            return 'J';
+        }
+    }
+}

--- a/avaje-jex/src/test/java/io/avaje/jex/http/RangeTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/http/RangeTest.java
@@ -1,0 +1,197 @@
+package io.avaje.jex.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jex.Jex;
+import io.avaje.jex.core.Constants;
+import io.avaje.jex.core.TestPair;
+
+class RangeTest {
+
+  static final TestPair pair = init();
+  private static final int chunkSize = 3000;
+
+  static TestPair init() {
+    final Jex app =
+        Jex.create()
+            .config(c -> c.rangeChunkSize(chunkSize))
+            .get(
+                "/range",
+                ctx -> ctx.contentType(ContentType.VIDEO_MPEG).rangedWrite(getInput()))
+            .get(
+                "/range-noaudiovideo",
+                ctx ->
+                    ctx.contentType(ContentType.APPLICATION_OCTET_STREAM)
+                        .rangedWrite(getInput()))
+            .get(
+                "/range-large",
+                ctx -> {
+                  long prefixSize = 1L << 31; // 2GB
+                  long contentSize = 100L;
+                  ctx.contentType(ContentType.TEXT_PLAIN)
+                      .rangedWrite(
+                          new LargeSeekableInput(prefixSize, contentSize),
+                          prefixSize + contentSize);
+                });
+
+    return TestPair.create(app);
+  }
+
+  private static ByteArrayInputStream getInput() {
+
+    return getInput(chunkSize);
+  }
+
+  private static ByteArrayInputStream getInput(int repeats) {
+    String repeatedString =
+        Stream.of("a", "b", "c").map(s -> s.repeat(repeats)).collect(Collectors.joining());
+    byte[] byteArray = repeatedString.getBytes(StandardCharsets.UTF_8);
+
+    return new ByteArrayInputStream(byteArray);
+  }
+
+  @AfterAll
+  static void end() {
+    pair.shutdown();
+  }
+
+  @Test
+  void downloadingWithoutRequestRange() {
+    HttpResponse<String> response = pair.request().path("range-noaudiovideo").GET().asString();
+
+    assertThat(response.body().getBytes()).isEqualTo(getInput().readAllBytes());
+    assertThat(response.statusCode()).isEqualTo(200);
+
+    assertThat(response.headers().firstValueAsLong(Constants.CONTENT_LENGTH).orElseThrow())
+        .isGreaterThan(0L);
+    assertThat(response.headers().firstValue(Constants.ACCEPT_RANGES).orElseThrow())
+        .isEqualTo("bytes");
+  }
+
+  @Test
+  void downloadingWithoutMaxRequestRange() {
+
+    HttpResponse<String> response =
+        pair.request()
+            .path("range-noaudiovideo")
+            .header(Constants.RANGE, "bytes=0-")
+            .GET()
+            .asString();
+
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.headers().firstValueAsLong(Constants.CONTENT_LENGTH).orElseThrow())
+        .isEqualTo(getInput().available());
+  }
+
+  @Test
+  void audioVideo_downloadingWithoutMaxRequestRange() {
+
+    HttpResponse<String> response =
+        pair.request().path("range").header(Constants.RANGE, "bytes=0-").GET().asString();
+
+    assertThat(response.statusCode()).isEqualTo(206);
+    assertThat(response.headers().firstValueAsLong(Constants.CONTENT_LENGTH).orElseThrow())
+        .isEqualTo(getInput().available() / 3);
+  }
+
+  @Test
+  void downloadResuming() {
+    ByteArrayInputStream input = getInput();
+    int available = input.available();
+
+    HttpResponse<String> response =
+        pair.request()
+            .path("range-noaudiovideo")
+            .header(Constants.RANGE, "bytes=" + chunkSize + "-")
+            .GET()
+            .asString();
+
+    assertThat(response.headers().firstValue(Constants.CONTENT_RANGE).orElseThrow())
+        .isEqualTo("bytes " + chunkSize + "-" + (available - 1) + "/" + available);
+    assertThat(
+            Integer.parseInt(response.headers().firstValue(Constants.CONTENT_LENGTH).orElseThrow()))
+        .isEqualTo(available - chunkSize);
+
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK_200.status());
+  }
+
+  @Test
+  void testNoCompression() {
+    ByteArrayInputStream input = getInput();
+    int available = input.available();
+
+    HttpResponse<String> response =
+        pair.request()
+            .path("range-noaudiovideo")
+            .header(Constants.RANGE, "bytes=" + chunkSize + "-")
+            .header(Constants.ACCEPT_ENCODING, "gzip")
+            .GET()
+            .asString();
+
+    assertThat(response.headers().firstValue(Constants.CONTENT_RANGE).orElseThrow())
+        .isEqualTo("bytes " + chunkSize + "-" + (available - 1) + "/" + available);
+    assertThat(
+            Integer.parseInt(response.headers().firstValue(Constants.CONTENT_LENGTH).orElseThrow()))
+        .isEqualTo(available - chunkSize);
+
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK_200.status());
+
+  }
+
+  @Test
+  void audioVideo_specificRange() {
+
+    HttpResponse<String> response =
+        pair.request()
+            .path("range")
+            .header(Constants.RANGE, "bytes=" + chunkSize + "-" + (chunkSize * 2 - 1))
+            .GET()
+            .asString();
+    assertThat(response.body()).contains("b").doesNotContain("a", "c");
+
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.PARTIAL_CONTENT_206.status());
+  }
+
+  @Test
+  void audioVideo_oversizedRange() {
+    HttpResponse<byte[]> response =
+        pair.request()
+            .path("range")
+            .header(Constants.RANGE, "bytes=0-" + chunkSize * 4)
+            .GET()
+            .asByteArray();
+    assertThat(response.body()).hasSize(chunkSize * 3);
+  }
+
+  @Test
+  void audioVideo_LargeFile() {
+    long prefixSize = 1L << 31; // 2GB
+    long contentSize = 100L;
+    HttpResponse<String> response =
+        pair.request()
+            .path("range-large")
+            .header(Constants.RANGE, "bytes=" + prefixSize + "-" + (prefixSize + contentSize - 1))
+            .GET()
+            .asString();
+
+    assertThat(response.headers().firstValue(Constants.CONTENT_RANGE).orElseThrow())
+        .isEqualTo(
+            "bytes "
+                + prefixSize
+                + "-"
+                + (prefixSize + contentSize - 1)
+                + "/"
+                + (prefixSize + contentSize));
+    assertThat(response.body()).hasSize((int) contentSize);
+    assertThat(response.body()).doesNotContain(" ");
+  }
+}


### PR DESCRIPTION
Adds support for Http-Range Requests

- adds range writer methods
- adds configuration for the range chunk size (video streams sucks at lower values because the server gets flooded by range requests)
- adds a content length method to skip the buffer
- disables compression on range requests 

Resolves #247 