### PR TITLE
Update parent pom for publishing to central (via central portal)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.avaje</groupId>
     <artifactId>java11-oss</artifactId>
-    <version>4.5</version>
+    <version>5.0</version>
   </parent>
 
   <groupId>io.avaje</groupId>


### PR DESCRIPTION
This is for updating the publishing to the new central portal (from the old s01.oss.sonatype.org)