### PR TITLE
#264 Use AppLog.getLogger() rather than direct System.getLogger() for native-image

### DIFF
--- a/avaje-jex-grizzly-spi/src/main/java/io/avaje/jex/grizzly/spi/GrizzlyHttpServer.java
+++ b/avaje-jex-grizzly-spi/src/main/java/io/avaje/jex/grizzly/spi/GrizzlyHttpServer.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import io.avaje.applog.AppLog;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
@@ -19,7 +20,7 @@ import com.sun.net.httpserver.HttpsConfigurator;
 
 final class GrizzlyHttpServer extends com.sun.net.httpserver.HttpsServer {
   private static final System.Logger LOG =
-      System.getLogger(GrizzlyHttpServer.class.getCanonicalName());
+      AppLog.getLogger(GrizzlyHttpServer.class.getCanonicalName());
   private final HttpServer server;
   private InetSocketAddress addr;
   private ServerConfiguration httpConfiguration;

--- a/avaje-jex-grizzly-spi/src/main/java/module-info.java
+++ b/avaje-jex-grizzly-spi/src/main/java/module-info.java
@@ -12,6 +12,7 @@ module io.avaje.jex.grizzly {
 
   requires static io.avaje.spi;
   requires static java.net.http;
+  requires io.avaje.applog;
 
-  provides HttpServerProvider with io.avaje.jex.grizzly.spi.GrizzlyHttpServerProvider;
+    provides HttpServerProvider with io.avaje.jex.grizzly.spi.GrizzlyHttpServerProvider;
 }

--- a/avaje-jex/pom.xml
+++ b/avaje-jex/pom.xml
@@ -18,6 +18,12 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
+      <artifactId>avaje-applog</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
       <artifactId>avaje-config</artifactId>
       <optional>true</optional>
     </dependency>

--- a/avaje-jex/src/main/java/io/avaje/jex/DefaultLifecycle.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DefaultLifecycle.java
@@ -1,5 +1,7 @@
 package io.avaje.jex;
 
+import io.avaje.applog.AppLog;
+
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -10,7 +12,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 final class DefaultLifecycle implements AppLifecycle {
 
-  private static final System.Logger log = System.getLogger("io.avaje.jex");
+  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 
   private final List<Pair> shutdownRunnable = new ArrayList<>();
   private final ReentrantLock lock = new ReentrantLock();

--- a/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BootstrapServer.java
@@ -11,6 +11,7 @@ import java.net.UnknownHostException;
 
 import com.sun.net.httpserver.HttpServer;
 
+import io.avaje.applog.AppLog;
 import io.avaje.jex.AppLifecycle;
 import io.avaje.jex.Jex;
 import io.avaje.jex.JexConfig;
@@ -21,7 +22,7 @@ public final class BootstrapServer {
 
   private BootstrapServer() {}
 
-  private static final System.Logger log = System.getLogger("io.avaje.jex");
+  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 
   public static Jex.Server start(Jex jex) {
     final var config = jex.config();

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ExceptionManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ExceptionManager.java
@@ -4,6 +4,7 @@ import static java.lang.System.Logger.Level.ERROR;
 
 import java.util.Map;
 
+import io.avaje.applog.AppLog;
 import io.avaje.jex.http.HttpStatus;
 import io.avaje.jex.http.Context;
 import io.avaje.jex.http.ExceptionHandler;
@@ -14,7 +15,7 @@ final class ExceptionManager {
 
   private static final String APPLICATION_JSON = "application/json";
 
-  private static final System.Logger log = System.getLogger("io.avaje.jex");
+  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 
   private final Map<Class<?>, ExceptionHandler<?>> handlers;
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkJexServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkJexServer.java
@@ -4,12 +4,13 @@ import java.lang.System.Logger.Level;
 
 import com.sun.net.httpserver.HttpServer;
 
+import io.avaje.applog.AppLog;
 import io.avaje.jex.AppLifecycle;
 import io.avaje.jex.Jex;
 
 final class JdkJexServer implements Jex.Server {
 
-  private static final System.Logger log = System.getLogger("io.avaje.jex");
+  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 
   private final HttpServer server;
   private final AppLifecycle lifecycle;

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import io.avaje.applog.AppLog;
 import io.avaje.jex.Jex;
 import io.avaje.jex.Routing;
 import io.avaje.jex.compression.CompressedOutputStream;
@@ -28,7 +29,7 @@ import io.avaje.jex.spi.TemplateRender;
 /** Core service methods available to Context implementations. */
 final class ServiceManager {
 
-  private static final System.Logger log = System.getLogger("io.avaje.jex");
+  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 
   private final CompressionConfig compressionConfig;
   private final JsonService jsonService;

--- a/avaje-jex/src/main/java/io/avaje/jex/http/sse/SseClientImpl.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/http/sse/SseClientImpl.java
@@ -8,12 +8,13 @@ import java.lang.System.Logger.Level;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.avaje.applog.AppLog;
 import io.avaje.jex.http.Context;
 import io.avaje.jex.spi.JsonService;
 
 final class SseClientImpl implements SseClient {
 
-  private static final System.Logger log = System.getLogger(SseClient.class.getCanonicalName());
+  private static final System.Logger log = AppLog.getLogger(SseClient.class.getCanonicalName());
 
   private final AtomicBoolean terminated = new AtomicBoolean(false);
   private final Emitter emitter;

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
@@ -6,12 +6,13 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 
+import io.avaje.applog.AppLog;
 import io.avaje.jex.Routing;
 import io.avaje.jex.http.HttpFilter;
 
 final class Routes implements SpiRoutes {
 
-  private static final System.Logger log = System.getLogger("io.avaje.jex");
+  private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
 
   /**
    * The "real" handlers by http method.

--- a/avaje-jex/src/main/java/module-info.java
+++ b/avaje-jex/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module io.avaje.jex {
 
   requires transitive java.net.http;
   requires transitive jdk.httpserver;
+  requires transitive io.avaje.applog;
   requires static com.fasterxml.jackson.core;
   requires static com.fasterxml.jackson.databind;
   requires static io.avaje.jsonb;

--- a/examples/example-jdk-jsonb/src/main/java/org/example/Main.java
+++ b/examples/example-jdk-jsonb/src/main/java/org/example/Main.java
@@ -3,6 +3,7 @@ package org.example;
 import java.util.Map;
 import java.util.Set;
 
+import io.avaje.applog.AppLog;
 import io.avaje.jex.Jex;
 import io.avaje.jex.core.json.JsonbJsonService;
 import io.avaje.jex.http.Context;
@@ -10,7 +11,7 @@ import io.avaje.jsonb.Jsonb;
 
 public class Main {
 
-  private static final  System.Logger log = System.getLogger("org.example");
+  private static final  System.Logger log = AppLog.getLogger("org.example");
 
   public static void main(String[] args) {
 


### PR DESCRIPTION
As per issue #264, when using GraalVM native-image using System.getLogger() directly is problematic for class initialisation. Using AppLog.getLogger() adds that one level of indirection that means we can successfully redirect the log messages to sl4j4-api and onto whatever backend is setup for that.