### PR TITLE
Add size limit to `Context#bodyAsBytes()`

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
@@ -29,6 +29,7 @@ final class DJexConfig implements JexConfig {
   private int bufferInitial = 256;
   private long bufferMax = 4096L;
   private int rangeChunkSize = 990_000;
+  private long maxRequestSize = 1_000_000L;
   private HttpServerProvider serverProvider;
 
   @Override
@@ -210,5 +211,16 @@ final class DJexConfig implements JexConfig {
   public JexConfig rangeChunkSize(int rangeChunkSize) {
     this.rangeChunkSize = rangeChunkSize;
     return this;
+  }
+
+  @Override
+  public JexConfig maxRequestSize(long maxRequestSize) {
+    this.maxRequestSize = maxRequestSize;
+    return this;
+  }
+
+  @Override
+  public long maxRequestSize() {
+    return maxRequestSize;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -150,6 +150,16 @@ public interface JexConfig {
   int rangeChunkSize();
 
   /**
+   * Sets the the max size of request body that can be accessed without using using an InputStream
+   *
+   * @param maxRequestSize The size.
+   */
+  JexConfig maxRequestSize(long maxRequestSize);
+
+  /** The configured maxRequestSize size */
+  long maxRequestSize();
+
+  /**
    * Set the chunk size on range requests, set to a high number to reduce the amount of range
    * requests (especially for video streaming)
    *

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -172,7 +172,7 @@ final class ServiceManager {
     return scheme;
   }
 
-  public long maxRequestSize() {
+  long maxRequestSize() {
     return maxRequestSize;
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -39,6 +39,7 @@ final class ServiceManager {
   private final int bufferInitial;
   private final long bufferMax;
   private final int rangeChunks;
+  private final long maxRequestSize;
 
   static ServiceManager create(Jex jex) {
     return new Builder(jex).build();
@@ -52,7 +53,8 @@ final class ServiceManager {
       String scheme,
       long bufferMax,
       int bufferInitial,
-      int rangeChunks) {
+      int rangeChunks,
+      long maxRequestSize) {
     this.compressionConfig = compressionConfig;
     this.jsonService = jsonService;
     this.exceptionHandler = manager;
@@ -61,6 +63,7 @@ final class ServiceManager {
     this.bufferInitial = bufferInitial;
     this.bufferMax = bufferMax;
     this.rangeChunks = rangeChunks;
+    this.maxRequestSize = maxRequestSize;
   }
 
   OutputStream createOutputStream(JdkContext jdkContext) {
@@ -169,6 +172,10 @@ final class ServiceManager {
     return scheme;
   }
 
+  public long maxRequestSize() {
+    return maxRequestSize;
+  }
+
   private static final class Builder {
 
     private final Jex jex;
@@ -186,7 +193,8 @@ final class ServiceManager {
           jex.config().scheme(),
           jex.config().maxStreamBufferSize(),
           jex.config().initialStreamBufferSize(),
-          jex.config().rangeChunkSize());
+          jex.config().rangeChunkSize(),
+          jex.config().maxRequestSize());
     }
 
     JsonService initJsonService() {

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextRequestTooBigTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextRequestTooBigTest.java
@@ -46,7 +46,6 @@ class ContextRequestTooBigTest {
     HttpURLConnection connection =
         (HttpURLConnection) URI.create(pair.url()).toURL().openConnection();
 
-    // 3. Configure the connection for a POST request
     connection.setRequestMethod("POST");
     connection.setDoOutput(true);
     connection.setChunkedStreamingMode(2);

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextRequestTooBigTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextRequestTooBigTest.java
@@ -1,0 +1,60 @@
+package io.avaje.jex.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jex.Jex;
+
+class ContextRequestTooBigTest {
+
+  static final TestPair pair = init();
+
+  static TestPair init() {
+    final Jex app =
+        Jex.create().config(c -> c.maxRequestSize(5)).post("/", ctx -> ctx.text(ctx.body()));
+
+    return TestPair.create(app);
+  }
+
+  @AfterAll
+  static void end() {
+    pair.shutdown();
+  }
+
+  @Test
+  void noBody() {
+    HttpResponse<String> res = pair.request().POST().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  void overSized() {
+    HttpResponse<String> res = pair.request().body("amogus").POST().asString();
+    assertThat(res.statusCode()).isEqualTo(413);
+  }
+
+  @Test
+  void transferEncoding() throws IOException {
+    HttpURLConnection connection =
+        (HttpURLConnection) URI.create(pair.url()).toURL().openConnection();
+
+    // 3. Configure the connection for a POST request
+    connection.setRequestMethod("POST");
+    connection.setDoOutput(true);
+    connection.setChunkedStreamingMode(2);
+
+    try (OutputStream os = connection.getOutputStream()) {
+      os.write("hi".getBytes());
+    }
+
+    assertThat(connection.getResponseCode()).isEqualTo(413);
+  }
+}


### PR DESCRIPTION
Adds a config option to prevent request bodies from getting too large