### PR TITLE
[ssl-plugin] Move default SSLContext to main module

### DIFF
--- a/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/DSslConfig.java
+++ b/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/DSslConfig.java
@@ -38,11 +38,11 @@ final class DSslConfig implements SslConfig {
     return identityPassword;
   }
 
-  public X509ExtendedKeyManager keyManager() {
+  X509ExtendedKeyManager keyManager() {
     return keyManager;
   }
 
-  public KeyStore keyStore() {
+  KeyStore keyStore() {
     return keyStore;
   }
 

--- a/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/DSslPlugin.java
+++ b/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/DSslPlugin.java
@@ -2,8 +2,6 @@ package io.avaje.jex.ssl;
 
 import java.util.function.Consumer;
 
-import javax.net.ssl.SSLContext;
-
 import com.sun.net.httpserver.HttpsConfigurator;
 
 import io.avaje.jex.Jex;
@@ -17,12 +15,7 @@ final class DSslPlugin implements SslPlugin {
     final var config = new DSslConfig();
 
     consumer.accept(config);
-    sslConfigurator = SslHttpConfigurator.create(config);
-  }
-
-  DSslPlugin(SSLContext context) {
-
-    this.sslConfigurator = new HttpsConfigurator(context);
+    sslConfigurator = SSLConfigurator.create(config);
   }
 
   @Override

--- a/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/SSLConfigurator.java
+++ b/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/SSLConfigurator.java
@@ -17,7 +17,7 @@ import javax.net.ssl.TrustManagerFactory;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsParameters;
 
-final class SslHttpConfigurator extends HttpsConfigurator {
+final class SSLConfigurator extends HttpsConfigurator {
 
   private static final String SSL_PROTOCOL = "TLSv1.3";
   private static final String KEY_MANAGER_ALGORITHM = "SunX509";
@@ -25,7 +25,7 @@ final class SslHttpConfigurator extends HttpsConfigurator {
 
   private final boolean clientAuth;
 
-  public SslHttpConfigurator(SSLContext context, boolean clientAuth) {
+  public SSLConfigurator(SSLContext context, boolean clientAuth) {
     super(context);
     this.clientAuth = clientAuth;
   }
@@ -37,7 +37,7 @@ final class SslHttpConfigurator extends HttpsConfigurator {
     params.setSSLParameters(sslParams);
   }
 
-  static SslHttpConfigurator create(DSslConfig sslConfig) throws SslConfigException {
+  static SSLConfigurator create(DSslConfig sslConfig) throws SslConfigException {
     try {
       var sslContext = createContext(sslConfig);
 
@@ -46,7 +46,7 @@ final class SslHttpConfigurator extends HttpsConfigurator {
 
       sslContext.init(keyManagers, trustManagers, new SecureRandom());
 
-      return new SslHttpConfigurator(sslContext, trustManagers != null);
+      return new SSLConfigurator(sslContext, trustManagers != null);
     } catch (Exception e) {
       throw new SslConfigException("Failed to build SSLContext", e);
     }

--- a/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/SslPlugin.java
+++ b/avaje-jex-ssl/src/main/java/io/avaje/jex/ssl/SslPlugin.java
@@ -2,8 +2,6 @@ package io.avaje.jex.ssl;
 
 import java.util.function.Consumer;
 
-import javax.net.ssl.SSLContext;
-
 import io.avaje.jex.spi.JexPlugin;
 
 /**
@@ -23,15 +21,6 @@ import io.avaje.jex.spi.JexPlugin;
  * }</pre>
  */
 public sealed interface SslPlugin extends JexPlugin permits DSslPlugin {
-
-  /**
-   * Configure SSL using an existing SSL Context
-   *
-   * @param sslContext The SSL Context to use for SSL.
-   */
-  static SslPlugin fromSslContext(SSLContext sslContext) {
-    return new DSslPlugin(sslContext);
-  }
 
   /**
    * Configure SSL using an existing SSL Context

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -5,6 +5,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
+import javax.net.ssl.SSLContext;
+
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.spi.HttpServerProvider;
@@ -80,11 +82,20 @@ public interface JexConfig {
   HttpsConfigurator httpsConfig();
 
   /**
-   * Enable https with the provided {@link HttpsConfigurator}
+   * Enable HTTPS and SSL with the provided {@link HttpsConfigurator}
    *
    * @param https The HTTPS configuration.
    */
   JexConfig httpsConfig(HttpsConfigurator https);
+
+  /**
+   * Configure HTTPS and SSL with the provided {@link SSLContext}.
+   *
+   * @param sslContext The SSLContext to use for HTTPS.
+   */
+  default JexConfig httpsConfig(SSLContext sslContext) {
+    return httpsConfig(new HttpsConfigurator(sslContext));
+  }
 
   /** Returns whether trailing slashes in request URIs are ignored. */
   boolean ignoreTrailingSlashes();


### PR DESCRIPTION
You wouldn't need the plugin if you had a configured `SSLContext` on hand.