### PR TITLE
Removes `baos` creation on content length

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/BufferedOutStream.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/BufferedOutStream.java
@@ -21,7 +21,6 @@ final class BufferedOutStream extends OutputStream {
     // if content length is set, skip buffer
     if (context.responseHeader(Constants.CONTENT_LENGTH) != null) {
       count = max + 1;
-      buffer = null;
     } else {
       buffer = new ByteArrayOutputStream(initial);
     }


### PR DESCRIPTION
Removes `ByteArrayOutputStream` initialization when content length is set