### PR TITLE
Allow Registering Routes with SPI

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/Routing.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Routing.java
@@ -14,6 +14,7 @@ import io.avaje.jex.http.ExchangeHandler;
 import io.avaje.jex.http.HttpFilter;
 import io.avaje.jex.http.sse.SseClient;
 import io.avaje.jex.security.Role;
+import io.avaje.jex.spi.JexExtension;
 
 /** Routing abstraction. */
 public interface Routing {
@@ -171,7 +172,7 @@ public interface Routing {
 
   /** Adds to the Routing. */
   @FunctionalInterface
-  interface HttpService {
+  non-sealed interface HttpService extends JexExtension {
 
     /**
      * Add to the routing.

--- a/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceLoader.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/CoreServiceLoader.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
+import io.avaje.jex.Routing.HttpService;
 import io.avaje.jex.spi.JexExtension;
 import io.avaje.jex.spi.JexPlugin;
 import io.avaje.jex.spi.JsonService;
@@ -18,6 +19,7 @@ final class CoreServiceLoader {
   private final JsonService jsonService;
   private final List<TemplateRender> renders = new ArrayList<>();
   private final List<JexPlugin> plugins = new ArrayList<>();
+  private final List<HttpService> spiRoutes = new ArrayList<>();
 
   CoreServiceLoader() {
     JsonService spiJsonService = null;
@@ -26,6 +28,7 @@ final class CoreServiceLoader {
         case JsonService s -> spiJsonService = s;
         case TemplateRender r -> renders.add(r);
         case JexPlugin p -> plugins.add(p);
+        case HttpService p -> spiRoutes.add(p);
       }
     }
     jsonService = spiJsonService;
@@ -41,5 +44,9 @@ final class CoreServiceLoader {
 
   static List<JexPlugin> plugins() {
     return INSTANCE.plugins;
+  }
+
+  static List<HttpService> spiRoutes() {
+    return INSTANCE.spiRoutes;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/spi/JexExtension.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/spi/JexExtension.java
@@ -1,5 +1,6 @@
 package io.avaje.jex.spi;
 
+import io.avaje.jex.Routing.HttpService;
 import io.avaje.spi.Service;
 
 /**
@@ -9,4 +10,4 @@ import io.avaje.spi.Service;
  * META-INF/services/io.avaje.jex.spi.JexExtension } for it to be auto loaded
  */
 @Service
-public sealed interface JexExtension permits JsonService, TemplateRender, JexPlugin {}
+public sealed interface JexExtension permits HttpService, JexPlugin, JsonService, TemplateRender {}

--- a/avaje-jex/src/test/java/io/avaje/jex/SpiRouteTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/SpiRouteTest.java
@@ -1,0 +1,30 @@
+package io.avaje.jex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jex.Routing.HttpService;
+import io.avaje.jex.core.TestPair;
+import io.avaje.spi.ServiceProvider;
+
+@ServiceProvider
+public class SpiRouteTest implements HttpService {
+
+  @Override
+  public void add(Routing routing) {
+
+    routing.get("/spi", ctx -> ctx.write("hello from spi"));
+  }
+
+  @Test
+  void get() {
+    var pair = TestPair.create(Jex.create());
+    HttpResponse<String> res = pair.request().path("spi").GET().asString();
+
+    assertThat(res.body()).isEqualTo("hello from spi");
+    pair.shutdown();
+  }
+}


### PR DESCRIPTION
Now can directly register routes with SPI.

```java
@ServiceProvider
public class SpiRoute implements HttpService {

  @Override
  public void add(Routing routing) {
    routing.get("/spi", ctx -> ctx.write("hello from spi"));
  }
}
```