### PR TITLE
add tiles-maven-plugin to bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,17 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>io.repaint.maven</groupId>
+          <artifactId>tiles-maven-plugin</artifactId>
+          <extensions>true</extensions>
+
+          <configuration>
+            <tiles>
+              <tile>io.ebean.tile:enhancement:${ebean.version}</tile>
+            </tiles>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>io.ebean</groupId>
           <artifactId>ebean-maven-plugin</artifactId>
           <version>${ebean.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,7 @@
         <plugin>
           <groupId>io.repaint.maven</groupId>
           <artifactId>tiles-maven-plugin</artifactId>
+          <version>2.41</version>
           <extensions>true</extensions>
 
           <configuration>


### PR DESCRIPTION
(#306)

> ### Maven enhancement tile
> This is simpler, cleaner less verbose than defining the plugin in the traditional (non-tile) fashion and now the preferred approach.
>
> (https://ebean.io/docs/setup/enhancement)


I have not tested whether this would clash with anything.

I believe that we can declare `pluginManagement` for both `tiles-maven-plugin` & `ebean-maven-plugin` and leave it up to the user