### PR TITLE
Update `readme` to specify virtual threads requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features:
 - Json SPI
 - File Uploads
 - SSL/mTLS configuration
-- Virtual threads enabled by default and required
+- Virtual thread executor by default (no Future-based programming model, etc)
 - Multi-Server with any implementation of `jdk.httpserver` (Jetty, Robaho, built-in, etc)
 
 ## Quick Start


### PR DESCRIPTION
Clarify that virtual threads aren't just a default or suggestion,
but a hard requirement.

Related-to: https://github.com/avaje/avaje-jex/pull/320#issuecomment-3505550077
Signed-off-by: Mahied Maruf <contact@mechite.com>