### PR TITLE
Allow disabling read size restriction

### DIFF
--- a/avaje-jex-test/src/main/java/io/avaje/jex/test/TestPair.java
+++ b/avaje-jex-test/src/main/java/io/avaje/jex/test/TestPair.java
@@ -51,7 +51,7 @@ public class TestPair implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     shutdown();
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -161,7 +161,9 @@ public interface JexConfig {
   int rangeChunkSize();
 
   /**
-   * Sets the the max size of request body that can be accessed without using using an InputStream
+   * Sets the the max size of request body that can be accessed without using using an InputStream.
+   *
+   * <p>providing -1 means there is no limit
    *
    * @param maxRequestSize The size.
    */

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -127,7 +127,7 @@ final class JdkContext implements Context {
       if (bodyBytes == null) {
         var contentLength = contentLength();
         long maxRequestSize = mgr.maxRequestSize();
-        if (contentLength > maxRequestSize || contentLength < 0) {
+        if (maxRequestSize > 0 && (contentLength > maxRequestSize || contentLength < 0)) {
           throw new HttpResponseException(
               HttpStatus.REQUEST_ENTITY_TOO_LARGE_413.status(),
               "Body content length unknown or greater than max configured size (%s bytes)"


### PR DESCRIPTION
Now can set max allowed body size to -1 to disable size restriction. This came about because the flupke httpclient doesn't seem to send content length headers