### PR TITLE
Edit `FlupkeSystemLogger` method to lock

### DIFF
--- a/avaje-jex-http3-flupke/src/main/java/io/avaje/jex/http3/flupke/FlupkeSystemLogger.java
+++ b/avaje-jex-http3-flupke/src/main/java/io/avaje/jex/http3/flupke/FlupkeSystemLogger.java
@@ -26,13 +26,12 @@ public class FlupkeSystemLogger extends BaseLogger {
 
   @Override
   protected void log(String text, Throwable throwable) {
-    if (throwable == null) {
-      LOG.log(Level.ERROR, text);
-      return;
-    }
-
     this.lock.lock();
     try {
+      if (throwable == null) {
+        LOG.log(Level.ERROR, text);
+        return;
+      }
       LOG.log(Level.ERROR, text, throwable);
     } finally {
       this.lock.unlock();


### PR DESCRIPTION
The `null` check that just output the message was previously not using
the lock, though I don't think it's a big issue and I'm not sure why
there is a lock in the first place.

I inherited that from Flupke, so it's better safe than sorry, though

I'm pretty sure System.Logger makes those guarantees, but so does even
`System.out`/`System.err`, so it's better to assume that ptrd had his
reasons for locking here

Signed-off-by: Mahied Maruf <contact@mechite.com>