### PR TITLE
Export package in `module-info` of `avaje-jex-http3-flupke`

### DIFF
--- a/avaje-jex-http3-flupke/src/main/java/module-info.java
+++ b/avaje-jex-http3-flupke/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module io.avaje.jex.http3.flupke {
   exports io.avaje.jex.http3.flupke;
+  exports io.avaje.jex.http3.flupke.webtransport;
   
   requires transitive io.avaje.jex.ssl;
   requires transitive tech.kwik.flupke;


### PR DESCRIPTION
Fixes: #335
(EDIT - workflow failed due to http 500 on mvn central)