### PR TITLE
Add Jex.Server onShutdown() method that takes order

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/Jex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/Jex.java
@@ -293,6 +293,19 @@ public interface Jex {
      */
     void onShutdown(Runnable onShutdown);
 
+    /**
+     * Registers a runnable to be executed when the application server is shutting down, with a
+     * specific order.
+     *
+     * <p>Runnables with lower order values will be executed first.
+     *
+     * <p>This runnable will be executed after all active requests have been processed.
+     *
+     * @param onShutdown The runnable to execute on shutdown.
+     * @param order The order in which to execute the runnable.
+     */
+    void onShutdown(Runnable onShutdown, int order);
+
     /** Shutdown the server. */
     void shutdown();
 

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkJexServer.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkJexServer.java
@@ -29,6 +29,11 @@ final class JdkJexServer implements Jex.Server {
   }
 
   @Override
+  public void onShutdown(Runnable onShutdown, int order) {
+    lifecycle.onShutdown(onShutdown, order);
+  }
+
+  @Override
   public void shutdown() {
     log.log(Level.TRACE, "starting shutdown");
     lifecycle.status(AppLifecycle.Status.STOPPING);

--- a/avaje-jex/src/test/java/io/avaje/jex/ShutDownTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/ShutDownTest.java
@@ -18,8 +18,10 @@ class ShutDownTest {
     jex.lifecycle().registerShutdownHook(() -> results.add("onHook"));
     var server = jex.start();
 
-    server.onShutdown(() -> results.add("serverShut"));
+    server.onShutdown(() -> results.add("serverShutFirst"), Integer.MIN_VALUE);
+    server.onShutdown(() -> results.add("serverShutLast"));
     server.shutdown();
-    assertThat(results).hasSize(2); // 2 because jvm shutdown won't run in a junit
+    assertThat(results).hasSize(3); // 2 because jvm shutdown won't run in a junit
+    assertThat(results).containsExactly("serverShutFirst", "onShut", "serverShutLast");
   }
 }


### PR DESCRIPTION
It has an existing onShutdown() to add a shutdown runnable as last, but it's useful to also control the ordering so adding this option to control the order.

Use case: Using Jex with Webview and there we want to ensure that the Webview is shutdown along with Jex via a shutdown hook (e.g. CTRL-C the process)