### PR TITLE
modify Jex.configureWith() to register Filters

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/DJex.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJex.java
@@ -3,6 +3,7 @@ package io.avaje.jex;
 import io.avaje.inject.BeanScope;
 import io.avaje.jex.core.BootstrapServer;
 import io.avaje.jex.core.CoreServiceLoader;
+import io.avaje.jex.http.HttpFilter;
 import io.avaje.jex.spi.*;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.spi.HttpServerProvider;
@@ -62,6 +63,7 @@ final class DJex implements Jex {
       plugin.apply(this);
     }
     routing.addAll(beanScope.list(Routing.HttpService.class));
+    beanScope.list(HttpFilter.class).forEach(this::filter);
     beanScope.getOptional(JsonService.class).ifPresent(this::jsonService);
     beanScope.getOptional(HttpsConfigurator.class).ifPresent(config()::httpsConfig);
     beanScope.getOptional(HttpServerProvider.class).ifPresent(config()::serverProvider);

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ConfigureWithFilterTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ConfigureWithFilterTest.java
@@ -1,0 +1,82 @@
+package io.avaje.jex.core;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.jex.Jex;
+import io.avaje.jex.http.HttpFilter;
+import io.avaje.jex.spi.JexPlugin;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpResponse;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigureWithFilterTest {
+
+  @Test
+  void httpFilterBean_isAutoCollected() {
+    AtomicInteger filterHits = new AtomicInteger();
+
+    HttpFilter filter =
+        (ctx, chain) -> {
+          filterHits.incrementAndGet();
+          ctx.header("x-filter", "applied");
+          chain.proceed();
+        };
+
+    try (BeanScope scope = BeanScope.builder().bean(HttpFilter.class, filter).build()) {
+
+      Jex app = Jex.create().configureWith(scope).routing(r -> r.get("/", ctx -> ctx.text("ok")));
+
+      try (TestPair pair = TestPair.create(app)) {
+        HttpResponse<String> res = pair.request().GET().asString();
+
+        assertThat(res.statusCode()).isEqualTo(200);
+        assertThat(res.body()).isEqualTo("ok");
+        assertThat(res.headers().firstValue("x-filter")).get().isEqualTo("applied");
+        assertThat(filterHits.get()).isEqualTo(1);
+      }
+    }
+  }
+
+  @Test
+  void httpFilterBean_and_jexPluginBean_bothApplied() {
+    AtomicInteger filterHits = new AtomicInteger();
+    AtomicInteger pluginFilterHits = new AtomicInteger();
+
+    HttpFilter filter =
+        (ctx, chain) -> {
+          filterHits.incrementAndGet();
+          ctx.header("x-filter", "applied");
+          chain.proceed();
+        };
+
+    JexPlugin plugin =
+        jex ->
+            jex.filter(
+                (ctx, chain) -> {
+                  pluginFilterHits.incrementAndGet();
+                  ctx.header("x-plugin-filter", "applied");
+                  chain.proceed();
+                });
+
+    try (BeanScope scope =
+        BeanScope.builder()
+            .bean(HttpFilter.class, filter)
+            .bean(JexPlugin.class, plugin)
+            .build()) {
+
+      Jex app = Jex.create().configureWith(scope).routing(r -> r.get("/", ctx -> ctx.text("ok")));
+
+      try (TestPair pair = TestPair.create(app)) {
+        HttpResponse<String> res = pair.request().GET().asString();
+
+        assertThat(res.statusCode()).isEqualTo(200);
+        assertThat(res.headers().firstValue("x-filter")).get().isEqualTo("applied");
+        assertThat(res.headers().firstValue("x-plugin-filter")).get().isEqualTo("applied");
+        assertThat(filterHits.get()).isEqualTo(1);
+        assertThat(pluginFilterHits.get()).isEqualTo(1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently to wire a Filter we need to wrap it as a JexPlugin. This change adds wiring any Filter instances from the BeanScope.

Note the decision here to wire Filters AFTER JexPlugins, so this implies that JexPlugins have higher precedence than Filters.