### PR TITLE
Fix query param URL decoding

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -423,7 +423,7 @@ final class JdkContext implements Context {
 
   private Map<String, List<String>> queryParams() {
     if (queryParams == null) {
-      queryParams = mgr.parseParamMap(queryString(), StandardCharsets.UTF_8);
+      queryParams = mgr.parseGetMap(exchange.getRequestURI().getRawQuery(), StandardCharsets.UTF_8);
     }
     return queryParams;
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -25,6 +25,8 @@ import io.avaje.jex.core.json.Jackson3JsonService;
 import io.avaje.jex.core.json.JacksonJsonService;
 import io.avaje.jex.core.json.JsonbJsonService;
 import io.avaje.jex.http.Context;
+import io.avaje.jex.http.HttpResponseException;
+import io.avaje.jex.http.HttpStatus;
 import io.avaje.jex.routes.UrlDecode;
 import io.avaje.jex.spi.JsonService;
 import io.avaje.jex.spi.TemplateRender;
@@ -162,15 +164,18 @@ final class ServiceManager {
   }
 
   Map<String, List<String>> formParamMap(Context ctx, Charset charset) {
-    return parseParamMap(ctx.body(), charset);
+    if (!"application/x-www-form-urlencoded".equals(ctx.contentType())) {
+      throw new HttpResponseException(HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
+    }
+    return parseToMap(ctx.body(), (in) -> URLDecoder.decode(in, charset));
   }
 
   Map<String, List<String>> parseParamMap(String body, Charset charset) {
-    return  parseToMap(body, (in) -> UrlDecode.decodeRFC3986(in, charset));
+    return parseToMap(body, (in) -> UrlDecode.decodeRFC3986(in, charset));
   }
 
   Map<String, List<String>> parseGetMap(String body, Charset charset) {
-    return  parseToMap(body, (in) -> URLDecoder.decode(in, charset));
+    return parseToMap(body, (in) -> URLDecoder.decode(in, charset));
   }
 
   String scheme() {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.System.Logger.Level;
 import java.lang.reflect.Type;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import io.avaje.applog.AppLog;
@@ -164,6 +166,22 @@ final class ServiceManager {
   }
 
   Map<String, List<String>> parseParamMap(String body, Charset charset) {
+    return  parseToMap(body, (in) -> UrlDecode.decodeRFC3986(in, charset));
+  }
+
+  Map<String, List<String>> parseGetMap(String body, Charset charset) {
+    return  parseToMap(body, (in) -> URLDecoder.decode(in, charset));
+  }
+
+  String scheme() {
+    return scheme;
+  }
+
+  long maxRequestSize() {
+    return maxRequestSize;
+  }
+
+  private static Map<String, List<String>> parseToMap(String body, UnaryOperator<String> decoder) {
     if (body == null || body.isEmpty()) {
       return Collections.emptyMap();
     }
@@ -176,24 +194,16 @@ final class ServiceManager {
       int eq = body.indexOf('=', start);
       String key, val;
       if (eq == -1 || eq > end) {
-        key = UrlDecode.decode(body.substring(start, end), charset);
+        key = decoder.apply(body.substring(start, end));
         val = "";
       } else {
-        key = UrlDecode.decode(body.substring(start, eq), charset);
-        val = UrlDecode.decode(body.substring(eq + 1, end), charset);
+        key = decoder.apply(body.substring(start, eq));
+        val = decoder.apply(body.substring(eq + 1, end));
       }
       map.computeIfAbsent(key, s -> new ArrayList<>()).add(val);
       start = end + 1;
     }
     return map;
-  }
-
-  String scheme() {
-    return scheme;
-  }
-
-  long maxRequestSize() {
-    return maxRequestSize;
   }
 
   private static final class Builder {

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
@@ -61,7 +61,7 @@ final class PathParser {
       final String name = paramNames.get(i - 1);
       if (name != null) {
         // null names for wildcard placeholders
-        pathMap.put(name, UrlDecode.decode(matcher.group(i)));
+        pathMap.put(name, UrlDecode.decodeRFC3986(matcher.group(i)));
       }
     }
     return pathMap;

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/UrlDecode.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/UrlDecode.java
@@ -7,11 +7,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class UrlDecode {
 
-  public static String decode(String s) {
-    return decode(s, UTF_8);
+  public static String decodeRFC3986(String s) {
+    return decodeRFC3986(s, UTF_8);
   }
 
-  public static String decode(String s, Charset charset) {
+  public static String decodeRFC3986(String s, Charset charset) {
     if (s.indexOf('+') == -1) {
       return URLDecoder.decode(s, charset);
     }

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
@@ -10,6 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ContextFormParamTest {
 
+  private static final String CONTENT_TYPE = "Content-Type";
+  private static final String CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
+
   static TestPair pair = init();
 
   static TestPair init() {
@@ -19,6 +22,7 @@ class ContextFormParamTest {
         .post("/formParams/{key}", ctx -> ctx.text("formParams:" + ctx.formParams(ctx.pathParam("key"))))
         .post("/formParam/{key}", ctx -> ctx.text("formParam:" + ctx.formParam(ctx.pathParam("key"))))
         .post("/formParamWithDefault/{key}", ctx -> ctx.text("formParam:" + ctx.formParam(ctx.pathParam("key"), "foo")))
+        .post("/reply", ctx -> ctx.text(ctx.formParam("message", "default")))
       );
     return TestPair.create(app);
   }
@@ -131,5 +135,186 @@ class ContextFormParamTest {
 
     assertThat(res.statusCode()).isEqualTo(200);
     assertThat(res.body()).isEqualTo("formParam:z");
+  }
+
+  @Test
+  void strictEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=He%20asked%3A%20%22Does%201%20%2B%201%20%2F%201%20%3D%20200%25%20for%20%27efficiency%27%3F%22")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void formEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=He+asked%3A+%22Does+1+%2B+1+%2F+1+%3D+200%25+for+%27efficiency%27%3F%22")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void strictEncoding_encodedPercent_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=100%2520")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("100%20");
+  }
+
+  @Test
+  void strictEncoding_encodedEquals_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=1%2B1=2")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void noSetValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("");
+  }
+
+  @Test
+  void unboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("=value")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("default");
+  }
+
+  @Test
+  void strictEncoding_afterUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("=value&message=1%2B1=2")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_beforeUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=1%2B1=2&=value")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_lowerHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%2a")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_upperHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%2A")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_emoji_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%F0%9F%9A%80")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("\uD83D\uDE80"); // 🚀
+  }
+
+  @Test
+  void strictEncoding_truncatedBytes_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%F0%9F")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("�");
+  }
+
+  @Test
+  void strictEncoding_nullByte_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=config.json%00.txt")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("config.json\0.txt");
+  }
+
+  @Test
+  void wrongContentType_rightBodyFormat_stillSends415() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", "aaaaaaaaaaaaaaa")
+      // Use "body" to bypass encoding
+      .body("message=hello+world")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(415);
   }
 }

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ContextFormParamTest {
 
-  private static final String CONTENT_TYPE = "Content-Type";
   private static final String CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
 
   static TestPair pair = init();

--- a/avaje-jex/src/test/java/io/avaje/jex/core/QueryParamTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/QueryParamTest.java
@@ -23,6 +23,8 @@ class QueryParamTest {
         .get("/queryString", ctx -> ctx.text("qs: "+ctx.queryString()))
         .get("/plus/{plus}", ctx -> ctx.text(ctx.pathParam("plus")+ctx.queryParam("plus")))
         .get("/scheme", ctx -> ctx.text("scheme: "+ctx.scheme()))
+        .get("/reply", ctx -> ctx.text(ctx.queryParam("message", "default")))
+        .get("/reply-all", ctx -> ctx.text(ctx.queryParams("messages").toString()))
       );
     return TestPair.create(app);
   }
@@ -155,4 +157,194 @@ class QueryParamTest {
     assertThat(res.body()).isEqualTo("scheme: http");
   }
 
+  @Test
+  void usingQueryParam_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply")
+      .queryParam("message","He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void strictEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=He%20asked%3A%20%22Does%201%20%2B%201%20%2F%201%20%3D%20200%25%20for%20%27efficiency%27%3F%22")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void formEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=He+asked%3A+%22Does+1+%2B+1+%2F+1+%3D+200%25+for+%27efficiency%27%3F%22")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void noParams_returnsDefault() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("default");
+  }
+
+  @Test
+  void strictEncoding_encodedPercent_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=100%2520")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("100%20");
+  }
+
+  @Test
+  void strictEncoding_encodedEquals_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=1%2B1=2")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void noSetValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("");
+  }
+
+  @Test
+  void unboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?=value")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("default");
+  }
+
+  @Test
+  void strictEncoding_afterUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?=value&message=1%2B1=2")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_beforeUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=1%2B1=2&=value")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_lowerHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%2a")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_upperHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%2A")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_emoji_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%F0%9F%9A%80")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("\uD83D\uDE80"); // 🚀
+  }
+
+  @Test
+  void strictEncoding_truncatedBytes_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%F0%9F")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("�");
+  }
+
+  @Test
+  void strictEncoding_nullByte_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=config.json%00.txt")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("config.json\0.txt");
+  }
+
+  @Test
+  void strictEncoding_repeatedInput_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply-all?messages=this&messages=is&messages=repeated")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("[this, is, repeated]");
+  }
+
+  @Test
+  void strictEncoding_lonePlus_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("plus/+?plus=+")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    // The first "+" comes from the path
+    //    because it should be an unmodified RFC 3986 parse
+    // The second " " comes from the query params
+    //    because the query params are subject to `application/x-www-form-urlencoded`
+    assertThat(res.body()).isEqualTo("+ ");
+  }
 }


### PR DESCRIPTION
I ran into a bug where query params weren't being decoded correctly and instead we were getting "+" characters where there were spaces, making them indistinguishable from normal plus signs.

I've also added test cases for a few other odd cases I could think of.

I'm not sure that the `strictEncoding_truncatedBytes_roundTripsCorrectly` is intended behaviour - it's strictly correct in that it has decoded the request correctly and replied with what it was sent, but it isn't a valid character. Also not sure if you want to do anything special with null characters.