### PR TITLE
RFC: Make Parsing configurable

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/DJexConfig.java
@@ -10,6 +10,7 @@ import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.spi.HttpServerProvider;
 
 import io.avaje.jex.compression.CompressionConfig;
+import io.avaje.jex.core.DParamParser;
 import io.avaje.jex.spi.JsonService;
 import io.avaje.jex.spi.TemplateRender;
 
@@ -31,6 +32,7 @@ final class DJexConfig implements JexConfig {
   private int rangeChunkSize = 990_000;
   private long maxRequestSize = 1_000_000L;
   private HttpServerProvider serverProvider;
+  private ParamParser paramParser = new DParamParser();
 
   @Override
   public JexConfig host(String host) {
@@ -60,6 +62,17 @@ final class DJexConfig implements JexConfig {
   public JexConfig socketBacklog(int socketBacklog) {
     this.socketBacklog = socketBacklog;
     return this;
+  }
+
+  @Override
+  public JexConfig useCustomParamParser(ParamParser paramParser) {
+    this.paramParser = paramParser;
+    return this;
+  }
+
+  @Override
+  public ParamParser paramParser() {
+    return paramParser;
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/JexConfig.java
@@ -12,6 +12,7 @@ import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.spi.HttpServerProvider;
 
 import io.avaje.jex.compression.CompressionConfig;
+import io.avaje.jex.core.DLegacyParamParser;
 import io.avaje.jex.spi.JsonService;
 import io.avaje.jex.spi.TemplateRender;
 
@@ -219,4 +220,34 @@ public interface JexConfig {
    *     default value is used
    */
   JexConfig socketBacklog(int backlog);
+
+  /**
+   * Use the legacy parsing behaviour for query, path, and form params.
+   * <p>
+   * This is <strong>not</strong> compliant with the specification, but matches the behaviour of Jex
+   *  pre-4.0. Unless you rely on that behaviour, it is <strong>not</strong> recommend you use it
+   *
+   * @since 4.0
+   */
+  default JexConfig useLegacyParsingBehaviour() {
+    return useCustomParamParser(new DLegacyParamParser());
+  }
+
+  /**
+   * Override the default (spec-compliant) parsing behaviour for query, path, and form params.
+   * <p>
+   * Unless you need to change the way parsing is done, it is <strong>not</strong> recommended
+   *   to override the default behaviour.
+   *
+   * @param paramParser The custom {@link ParamParser} to use
+   * @since 4.0
+   */
+  JexConfig useCustomParamParser(final ParamParser paramParser);
+
+  /**
+   * Obtain the currently configured param parser.
+   *
+   * @since 4.0
+   */
+  ParamParser paramParser();
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/ParamParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/ParamParser.java
@@ -1,0 +1,167 @@
+package io.avaje.jex;
+
+import io.avaje.jex.http.Context;
+import io.avaje.jex.routes.DPathParser;
+
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+/**
+ * Parser for the various parameter types (path, query, body).
+ * <p>
+ * When overriding this class, you may use the helper methods
+ * {@link #decodeListAsRfc3986(String, Charset)},
+ * {@link #defaultPathParser(String, boolean)}, and/or
+ * {@link #decodeListAsUrlEncoded(String, Charset)} to assist you.
+ * <p>
+ * The default implementation acts as below:
+ * <ul>
+ *   <li>Query params are parsed as {@code application/x-www-form-urlencoded}</li>
+ *   <li>Path params are parsed as per RFC 3986</li>
+ *   <li>Bodies are parsed depending on the incoming {@code Content-Type}:
+ *    <ul>
+ *      <li>If it's {@code application/x-www-form-urlencoded}, then parse as that</li>
+ *      <li>If it's {@code multipart/form-data}, then you should use {@code avaje-jex-file-upload}</li>
+ *      <li>Otherwise, you must provide another parser (e.g. {@code application/json} using {@code avaje-jsonb}),
+ *      otherwise your users will receive a {@code 415 UNSUPPORTED MEDIA TYPE)</li>
+ *    </ul>
+ *   </li>
+ * </ul>
+ *
+ * @since 4.0
+ */
+public abstract class ParamParser {
+
+  /**
+   * Decode the query params. This is invoked the first time per-request
+   *    when {@link Context#queryParamMap()} or any other query param method is used.
+   *
+   * @param ctx The context of the request
+   * @param charset The charset to use
+   * @return The parsed query params
+   */
+  public abstract Map<String, List<String>> decodeQueryParams(final Context ctx, final Charset charset);
+
+  /**
+   * Decode a request body. This is invoked the first time per-request
+   *    when {@link Context#formParamMap()} or any other form param method is used.
+   *
+   * @param ctx The context of the request
+   * @param charset The charset to use
+   * @return The parsed body
+   */
+  public abstract Map<String, List<String>> decodeBody(final Context ctx, final Charset charset);
+
+  /**
+   * Create a path parser. These are constructed once, at start-up,
+   *    with some methods within them being invoked every request.
+   *
+   * @param path The entire path to parse
+   * @param routeEntry The route entry
+   * @param ignoreTrailingSlashes If trailing slashes should be ignored
+   * @return The PathParser instance for the given path
+   */
+  public abstract PathParser createPathParser(final String path, final Routing.Entry routeEntry, final boolean ignoreTrailingSlashes);
+
+  /**
+   * Create a default {@link PathParser} implementation that complies with the RFC 3986 spec.
+   *
+   * @param path The path to parse
+   * @param ignoreTrailingSlashes If trailing slashes should be ignored
+   * @return The default path parser
+   */
+  public final PathParser defaultPathParser(final String path, final boolean ignoreTrailingSlashes) {
+    return new DPathParser(path, ignoreTrailingSlashes);
+  }
+
+  /**
+   * Provide decoding based on RFC 3986, into a key -> list of values.
+   *
+   * @param input The input to try and parse
+   * @param charset The character set to parse as
+   * @return The decoded input
+   */
+  public final Map<String, List<String>> decodeListAsRfc3986(final String input, final Charset charset) {
+    return parseToMapList(input, charset, true);
+  }
+
+  /**
+   * Provide decoding based on {@code application/x-www-form-urlencoded}, into a key -> list of values.
+   * <p>
+   * This is usually used for query parameters and form bodies
+   *
+   * @param input The input to try and parse
+   * @param charset The character set to parse as
+   * @return The decoded input
+   */
+  public final Map<String, List<String>> decodeListAsUrlEncoded(final String input, final Charset charset) {
+    return parseToMapList(input, charset, false);
+  }
+
+  /**
+   * Internal default map parsing
+   *
+   * @param input The input as a string to be decoded
+   * @param charset The charset to use
+   * @param useRfc3986 If we should use RFC 3986 parsing (true), or standard form encoding (false)
+   * @return A map of key, to a list of its values
+   */
+  private static Map<String, List<String>> parseToMapList(final String input, final Charset charset, final boolean useRfc3986) {
+    if (input == null || input.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, List<String>> map = new LinkedHashMap<>();
+    int start = 0;
+    int len = input.length();
+
+    while (start < len) {
+      int amp = input.indexOf('&', start);
+      int end = amp == -1 ? len : amp;
+      int eq = input.indexOf('=', start);
+
+      String key, val;
+      if (eq == -1 || eq > end) {
+        key = decode(input.substring(start, end), charset, useRfc3986);
+        val = "";
+      } else {
+        key = decode(input.substring(start, eq), charset, useRfc3986);
+        val = decode(input.substring(eq + 1, end), charset, useRfc3986);
+      }
+      map.computeIfAbsent(key, s -> new ArrayList<>()).add(val);
+      start = end + 1;
+    }
+    return map;
+  }
+
+  /**
+   * Internal utility to decode a string
+   *
+   * @param s The string to decode
+   * @param charset The charset to decode as
+   * @param useRfc3986 If we should use RFC 3986 parsing (true), or standard form encoding (false)
+   * @return The decoded string
+   */
+  private static String decode(String s, Charset charset, boolean useRfc3986) {
+    return useRfc3986 ? rfc3986decode(s, charset) : URLDecoder.decode(s, charset);
+  }
+
+  /**
+   * Internal utility to help decode using RFC 3986
+   *
+   * @param s The string to decode
+   * @param charset The character set to decode in
+   * @return The RFC 3986 decoded version
+   */
+  private static String rfc3986decode(final String s, final Charset charset) {
+    if (s.indexOf('+') == -1) {
+      return URLDecoder.decode(s, charset);
+    }
+    return URLDecoder.decode(s.replace("+", "%2B"), charset).replace("%2B", "+");
+  }
+}

--- a/avaje-jex/src/main/java/io/avaje/jex/PathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/PathParser.java
@@ -1,0 +1,52 @@
+package io.avaje.jex;
+
+import io.avaje.jex.http.Context;
+
+import java.util.Map;
+
+/**
+ * A parser for URL paths.
+ * <p>
+ * It is recommended to use the default, which is compliant with the specification.
+ *
+ * @since 4.0
+ */
+public abstract class PathParser {
+
+  /**
+   * Test if the provided URL matches this PathParser. This is invoked every routing request.
+   *
+   * @param url The URL to test
+   * @return If it matches
+   */
+  public abstract boolean matches(final String url);
+
+  /**
+   * Extract all the path params out of the provided URI. This is invoked the once the first time
+   *    a {@link Context#pathParamMap()} or any other path param method is used.
+   *
+   * @param uri The URI to parse
+   * @return The path parameters
+   */
+  public abstract Map<String, String> extractPathParams(String uri);
+
+  /**
+   * Return the raw path that was parsed (match path).
+   */
+  public abstract String raw();
+
+  /**
+   * Return the number of path segments.
+   */
+  public abstract int segmentCount();
+
+  /**
+   * Return true if one of the segments is wildcard or slash accepting.
+   */
+  public abstract boolean multiSlash();
+
+  /**
+   * Return true if all path segments are literal.
+   */
+  public abstract boolean literal();
+}

--- a/avaje-jex/src/main/java/io/avaje/jex/core/DLegacyParamParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/DLegacyParamParser.java
@@ -1,0 +1,29 @@
+package io.avaje.jex.core;
+
+import io.avaje.jex.ParamParser;
+import io.avaje.jex.PathParser;
+import io.avaje.jex.Routing;
+import io.avaje.jex.http.Context;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This implementation is for the pre-4.0 behaviour regarding parsing query/form params
+ */
+public final class DLegacyParamParser extends ParamParser {
+  @Override
+  public Map<String, List<String>> decodeQueryParams(Context ctx, Charset charset) {
+    return decodeListAsRfc3986(ctx.queryString(), charset);
+  }
+
+  @Override
+  public Map<String, List<String>> decodeBody(Context ctx, Charset charset) {
+    return decodeListAsRfc3986(ctx.body(), charset);
+  }
+
+  @Override
+  public PathParser createPathParser(String path, Routing.Entry routeEntry, boolean ignoreTrailingSlashes) {
+    return defaultPathParser(path, ignoreTrailingSlashes);
+  }
+}

--- a/avaje-jex/src/main/java/io/avaje/jex/core/DParamParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/DParamParser.java
@@ -1,0 +1,36 @@
+package io.avaje.jex.core;
+
+import io.avaje.jex.ParamParser;
+import io.avaje.jex.PathParser;
+import io.avaje.jex.Routing;
+import io.avaje.jex.http.Context;
+import io.avaje.jex.http.HttpResponseException;
+import io.avaje.jex.http.HttpStatus;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This implements spec-compliant parsing of query, path, and body params
+ */
+public final class DParamParser extends ParamParser {
+
+  @Override
+  public Map<String, List<String>> decodeQueryParams(Context ctx, Charset charset) {
+    return decodeListAsUrlEncoded(ctx.exchange().getRequestURI().getRawQuery(), charset);
+  }
+
+  @Override
+  public Map<String, List<String>> decodeBody(Context ctx, Charset charset) {
+    if (!"application/x-www-form-urlencoded".equals(ctx.contentType())) {
+      throw new HttpResponseException(HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
+    }
+    return decodeListAsUrlEncoded(ctx.body(), charset);
+  }
+
+  @Override
+  public PathParser createPathParser(String path, Routing.Entry routeEntry, boolean ignoreTrailingSlashes) {
+    return defaultPathParser(path, ignoreTrailingSlashes);
+  }
+}

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -423,7 +423,7 @@ final class JdkContext implements Context {
 
   private Map<String, List<String>> queryParams() {
     if (queryParams == null) {
-      queryParams = mgr.parseParamMap(queryString(), StandardCharsets.UTF_8);
+      queryParams = mgr.parseGetMap(exchange.getRequestURI().getRawQuery(), StandardCharsets.UTF_8);
     }
     return queryParams;
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -423,7 +423,7 @@ final class JdkContext implements Context {
 
   private Map<String, List<String>> queryParams() {
     if (queryParams == null) {
-      queryParams = mgr.parseGetMap(exchange.getRequestURI().getRawQuery(), StandardCharsets.UTF_8);
+      queryParams = mgr.parseQueryParamMap(this, characterEncoding());
     }
     return queryParams;
   }

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -25,6 +25,8 @@ import io.avaje.jex.core.json.Jackson3JsonService;
 import io.avaje.jex.core.json.JacksonJsonService;
 import io.avaje.jex.core.json.JsonbJsonService;
 import io.avaje.jex.http.Context;
+import io.avaje.jex.http.HttpResponseException;
+import io.avaje.jex.http.HttpStatus;
 import io.avaje.jex.routes.UrlDecode;
 import io.avaje.jex.spi.JsonService;
 import io.avaje.jex.spi.TemplateRender;
@@ -162,15 +164,18 @@ final class ServiceManager {
   }
 
   Map<String, List<String>> formParamMap(Context ctx, Charset charset) {
-    return parseParamMap(ctx.body(), charset);
+    if (!"application/x-www-form-urlencoded".equals(ctx.contentType())) {
+      throw new HttpResponseException(HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
+    }
+    return parseToMap(ctx.body(), (in) -> URLDecoder.decode(in, charset));
   }
 
   Map<String, List<String>> parseParamMap(String body, Charset charset) {
-    return  parseToMap(body, (in) -> UrlDecode.decodeRFC3986(in, charset));
+    return parseToMap(body, (in) -> UrlDecode.decodeRFC3986(in, charset));
   }
 
   Map<String, List<String>> parseGetMap(String body, Charset charset) {
-    return  parseToMap(body, (in) -> URLDecoder.decode(in, charset));
+    return parseToMap(body, (in) -> URLDecoder.decode(in, charset));
   }
 
   String scheme() {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.System.Logger.Level;
 import java.lang.reflect.Type;
+import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import io.avaje.applog.AppLog;
@@ -164,6 +166,22 @@ final class ServiceManager {
   }
 
   Map<String, List<String>> parseParamMap(String body, Charset charset) {
+    return  parseToMap(body, (in) -> UrlDecode.decodeRFC3986(in, charset));
+  }
+
+  Map<String, List<String>> parseGetMap(String body, Charset charset) {
+    return  parseToMap(body, (in) -> URLDecoder.decode(in, charset));
+  }
+
+  String scheme() {
+    return scheme;
+  }
+
+  long maxRequestSize() {
+    return maxRequestSize;
+  }
+
+  private static Map<String, List<String>> parseToMap(String body, UnaryOperator<String> decoder) {
     if (body == null || body.isEmpty()) {
       return Collections.emptyMap();
     }
@@ -176,24 +194,16 @@ final class ServiceManager {
       int eq = body.indexOf('=', start);
       String key, val;
       if (eq == -1 || eq > end) {
-        key = UrlDecode.decode(body.substring(start, end), charset);
+        key = decoder.apply(body.substring(start, end));
         val = "";
       } else {
-        key = UrlDecode.decode(body.substring(start, eq), charset);
-        val = UrlDecode.decode(body.substring(eq + 1, end), charset);
+        key = decoder.apply(body.substring(start, eq));
+        val = decoder.apply(body.substring(eq + 1, end));
       }
       map.computeIfAbsent(key, s -> new ArrayList<>()).add(val);
       start = end + 1;
     }
     return map;
-  }
-
-  String scheme() {
-    return scheme;
-  }
-
-  long maxRequestSize() {
-    return maxRequestSize;
   }
 
   private static final class Builder {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -4,7 +4,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.System.Logger.Level;
 import java.lang.reflect.Type;
-import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -18,6 +17,7 @@ import java.util.stream.Stream;
 
 import io.avaje.applog.AppLog;
 import io.avaje.jex.Jex;
+import io.avaje.jex.ParamParser;
 import io.avaje.jex.Routing;
 import io.avaje.jex.compression.CompressedOutputStream;
 import io.avaje.jex.compression.CompressionConfig;
@@ -25,9 +25,6 @@ import io.avaje.jex.core.json.Jackson3JsonService;
 import io.avaje.jex.core.json.JacksonJsonService;
 import io.avaje.jex.core.json.JsonbJsonService;
 import io.avaje.jex.http.Context;
-import io.avaje.jex.http.HttpResponseException;
-import io.avaje.jex.http.HttpStatus;
-import io.avaje.jex.routes.UrlDecode;
 import io.avaje.jex.spi.JsonService;
 import io.avaje.jex.spi.TemplateRender;
 
@@ -35,7 +32,7 @@ import io.avaje.jex.spi.TemplateRender;
 final class ServiceManager {
 
   private static final System.Logger log = AppLog.getLogger("io.avaje.jex");
-
+  private final ParamParser paramParser;
   private final CompressionConfig compressionConfig;
   private final JsonService jsonService;
   private final ExceptionManager exceptionHandler;
@@ -59,7 +56,8 @@ final class ServiceManager {
       long bufferMax,
       int bufferInitial,
       int rangeChunks,
-      long maxRequestSize) {
+      long maxRequestSize,
+      ParamParser paramParser) {
     this.compressionConfig = compressionConfig;
     this.jsonService = jsonService;
     this.exceptionHandler = manager;
@@ -69,6 +67,7 @@ final class ServiceManager {
     this.bufferMax = bufferMax;
     this.rangeChunks = rangeChunks;
     this.maxRequestSize = maxRequestSize;
+    this.paramParser = paramParser;
   }
 
   OutputStream createOutputStream(JdkContext jdkContext) {
@@ -164,18 +163,11 @@ final class ServiceManager {
   }
 
   Map<String, List<String>> formParamMap(Context ctx, Charset charset) {
-    if (!"application/x-www-form-urlencoded".equals(ctx.contentType())) {
-      throw new HttpResponseException(HttpStatus.UNSUPPORTED_MEDIA_TYPE_415);
-    }
-    return parseToMap(ctx.body(), (in) -> URLDecoder.decode(in, charset));
+    return paramParser.decodeBody(ctx, charset);
   }
 
-  Map<String, List<String>> parseParamMap(String body, Charset charset) {
-    return parseToMap(body, (in) -> UrlDecode.decodeRFC3986(in, charset));
-  }
-
-  Map<String, List<String>> parseGetMap(String body, Charset charset) {
-    return parseToMap(body, (in) -> URLDecoder.decode(in, charset));
+  Map<String, List<String>> parseQueryParamMap(Context ctx, Charset charset) {
+    return paramParser.decodeQueryParams(ctx, charset);
   }
 
   String scheme() {
@@ -184,31 +176,6 @@ final class ServiceManager {
 
   long maxRequestSize() {
     return maxRequestSize;
-  }
-
-  private static Map<String, List<String>> parseToMap(String body, UnaryOperator<String> decoder) {
-    if (body == null || body.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    Map<String, List<String>> map = new LinkedHashMap<>();
-    int start = 0;
-    int len = body.length();
-    while (start < len) {
-      int amp = body.indexOf('&', start);
-      int end = amp == -1 ? len : amp;
-      int eq = body.indexOf('=', start);
-      String key, val;
-      if (eq == -1 || eq > end) {
-        key = decoder.apply(body.substring(start, end));
-        val = "";
-      } else {
-        key = decoder.apply(body.substring(start, eq));
-        val = decoder.apply(body.substring(eq + 1, end));
-      }
-      map.computeIfAbsent(key, s -> new ArrayList<>()).add(val);
-      start = end + 1;
-    }
-    return map;
   }
 
   private static final class Builder {
@@ -229,7 +196,8 @@ final class ServiceManager {
           jex.config().maxStreamBufferSize(),
           jex.config().initialStreamBufferSize(),
           jex.config().rangeChunkSize(),
-          jex.config().maxRequestSize());
+          jex.config().maxRequestSize(),
+          jex.config().paramParser());
     }
 
     JsonService initJsonService() {

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/DPathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/DPathParser.java
@@ -1,10 +1,12 @@
 package io.avaje.jex.routes;
 
+import io.avaje.jex.PathParser;
+
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-final class PathParser {
+public final class DPathParser extends PathParser {
 
   private final String rawPath;
   private final List<String> paramNames = new ArrayList<>();
@@ -15,7 +17,7 @@ final class PathParser {
   private final boolean ignoreTrailingSlashes;
   private int segmentCount;
 
-  PathParser(String path, boolean ignoreTrailingSlashes) {
+  public DPathParser(String path, boolean ignoreTrailingSlashes) {
     this.rawPath = path;
     this.ignoreTrailingSlashes = ignoreTrailingSlashes;
     final RegBuilder regBuilder = new RegBuilder(ignoreTrailingSlashes);
@@ -35,7 +37,8 @@ final class PathParser {
     this.literal = segmentCount > 1 && regBuilder.literal();
   }
 
-  boolean matches(String url) {
+  @Override
+  public boolean matches(String url) {
     if (literal) {
       int pathLen = rawPath.length();
       int urlLen = url.length();
@@ -50,7 +53,9 @@ final class PathParser {
     return matchRegex.matcher(url).matches();
   }
 
-  Map<String, String> extractPathParams(String uri) {
+
+  @Override
+  public Map<String, String> extractPathParams(String uri) {
     final Matcher matcher = pathParamRegex.matcher(uri);
     if (!matcher.find()) {
       return Map.of();
@@ -74,28 +79,32 @@ final class PathParser {
   /**
    * Return the raw path that was parsed (match path).
    */
-  String raw() {
+  @Override
+  public String raw() {
     return rawPath;
   }
 
   /**
    * Return the number of path segments.
    */
-  int segmentCount() {
+  @Override
+  public int segmentCount() {
     return segmentCount;
   }
 
   /**
    * Return true if one of the segments is wildcard or slash accepting.
    */
-  boolean multiSlash() {
+  @Override
+  public boolean multiSlash() {
     return multiSlash;
   }
 
   /**
    * Return true if all path segments are literal.
    */
-  boolean literal() {
+  @Override
+  public boolean literal() {
     return literal;
   }
 }

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/PathParser.java
@@ -61,7 +61,7 @@ final class PathParser {
       final String name = paramNames.get(i - 1);
       if (name != null) {
         // null names for wildcard placeholders
-        pathMap.put(name, UrlDecode.decode(matcher.group(i)));
+        pathMap.put(name, UrlDecode.decodeRFC3986(matcher.group(i)));
       }
     }
     return pathMap;

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RegBuilder.java
@@ -5,7 +5,7 @@ import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
 /**
- * Helper for PathParser to build regex for the path.
+ * Helper for DPathParser to build regex for the path.
  */
 final class RegBuilder {
   private final StringJoiner full = new StringJoiner("/");

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.avaje.jex.PathParser;
 import io.avaje.jex.http.ExchangeHandler;
 import io.avaje.jex.security.Role;
 

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RoutesBuilder.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RoutesBuilder.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import io.avaje.jex.JexConfig;
+import io.avaje.jex.ParamParser;
+import io.avaje.jex.PathParser;
 import io.avaje.jex.Routing;
 import io.avaje.jex.http.HttpFilter;
 
@@ -19,16 +21,17 @@ public final class RoutesBuilder {
     this.ignoreTrailingSlashes = config.ignoreTrailingSlashes();
     final var buildMap = new LinkedHashMap<Routing.Type, RouteIndexBuild>();
     this.contextPath = config.contextPath().transform(s -> "/".equals(s) ? "" : s);
+    final ParamParser paramParser = config.paramParser();
     for (var handler : routing.handlers()) {
-      buildMap.computeIfAbsent(handler.getType(), h -> new RouteIndexBuild()).add(convert(handler));
+      buildMap.computeIfAbsent(handler.getType(), h -> new RouteIndexBuild()).add(convert(handler, paramParser));
     }
     buildMap.forEach((key, value) -> typeMap.put(key, value.build()));
     filters = List.copyOf(routing.filters());
   }
 
-  private SpiRoutes.Entry convert(Routing.Entry handler) {
+  private SpiRoutes.Entry convert(Routing.Entry handler, ParamParser paramParser) {
     final PathParser pathParser =
-        new PathParser(contextPath + handler.getPath(), ignoreTrailingSlashes);
+      paramParser.createPathParser(contextPath + handler.getPath(), handler, ignoreTrailingSlashes);
     return new RouteEntry(pathParser, handler.getHandler(), handler.getRoles());
   }
 

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/UrlDecode.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/UrlDecode.java
@@ -7,11 +7,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class UrlDecode {
 
-  public static String decode(String s) {
-    return decode(s, UTF_8);
+  public static String decodeRFC3986(String s) {
+    return decodeRFC3986(s, UTF_8);
   }
 
-  public static String decode(String s, Charset charset) {
+  public static String decodeRFC3986(String s, Charset charset) {
     if (s.indexOf('+') == -1) {
       return URLDecoder.decode(s, charset);
     }

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
@@ -10,6 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ContextFormParamTest {
 
+  private static final String CONTENT_TYPE = "Content-Type";
+  private static final String CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
+
   static TestPair pair = init();
 
   static TestPair init() {
@@ -19,6 +22,7 @@ class ContextFormParamTest {
         .post("/formParams/{key}", ctx -> ctx.text("formParams:" + ctx.formParams(ctx.pathParam("key"))))
         .post("/formParam/{key}", ctx -> ctx.text("formParam:" + ctx.formParam(ctx.pathParam("key"))))
         .post("/formParamWithDefault/{key}", ctx -> ctx.text("formParam:" + ctx.formParam(ctx.pathParam("key"), "foo")))
+        .post("/reply", ctx -> ctx.text(ctx.formParam("message", "default")))
       );
     return TestPair.create(app);
   }
@@ -131,5 +135,186 @@ class ContextFormParamTest {
 
     assertThat(res.statusCode()).isEqualTo(200);
     assertThat(res.body()).isEqualTo("formParam:z");
+  }
+
+  @Test
+  void strictEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=He%20asked%3A%20%22Does%201%20%2B%201%20%2F%201%20%3D%20200%25%20for%20%27efficiency%27%3F%22")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void formEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=He+asked%3A+%22Does+1+%2B+1+%2F+1+%3D+200%25+for+%27efficiency%27%3F%22")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void strictEncoding_encodedPercent_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=100%2520")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("100%20");
+  }
+
+  @Test
+  void strictEncoding_encodedEquals_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=1%2B1=2")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void noSetValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("");
+  }
+
+  @Test
+  void unboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("=value")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("default");
+  }
+
+  @Test
+  void strictEncoding_afterUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("=value&message=1%2B1=2")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_beforeUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=1%2B1=2&=value")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_lowerHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%2a")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_upperHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%2A")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_emoji_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%F0%9F%9A%80")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("\uD83D\uDE80"); // 🚀
+  }
+
+  @Test
+  void strictEncoding_truncatedBytes_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=%F0%9F")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("�");
+  }
+
+  @Test
+  void strictEncoding_nullByte_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", CONTENT_TYPE_VALUE)
+      // Use "body" to bypass encoding
+      .body("message=config.json%00.txt")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("config.json\0.txt");
+  }
+
+  @Test
+  void wrongContentType_rightBodyFormat_stillSends415() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .header("Content-Type", "aaaaaaaaaaaaaaa")
+      // Use "body" to bypass encoding
+      .body("message=hello+world")
+      .POST()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(415);
   }
 }

--- a/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/ContextFormParamTest.java
@@ -10,7 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ContextFormParamTest {
 
-  private static final String CONTENT_TYPE = "Content-Type";
   private static final String CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
 
   static TestPair pair = init();

--- a/avaje-jex/src/test/java/io/avaje/jex/core/QueryParamTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/core/QueryParamTest.java
@@ -23,6 +23,8 @@ class QueryParamTest {
         .get("/queryString", ctx -> ctx.text("qs: "+ctx.queryString()))
         .get("/plus/{plus}", ctx -> ctx.text(ctx.pathParam("plus")+ctx.queryParam("plus")))
         .get("/scheme", ctx -> ctx.text("scheme: "+ctx.scheme()))
+        .get("/reply", ctx -> ctx.text(ctx.queryParam("message", "default")))
+        .get("/reply-all", ctx -> ctx.text(ctx.queryParams("messages").toString()))
       );
     return TestPair.create(app);
   }
@@ -155,4 +157,194 @@ class QueryParamTest {
     assertThat(res.body()).isEqualTo("scheme: http");
   }
 
+  @Test
+  void usingQueryParam_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply")
+      .queryParam("message","He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void strictEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=He%20asked%3A%20%22Does%201%20%2B%201%20%2F%201%20%3D%20200%25%20for%20%27efficiency%27%3F%22")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void formEncoding_complexMessage_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=He+asked%3A+%22Does+1+%2B+1+%2F+1+%3D+200%25+for+%27efficiency%27%3F%22")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("He asked: \"Does 1 + 1 / 1 = 200% for 'efficiency'?\"");
+  }
+
+  @Test
+  void noParams_returnsDefault() {
+    final HttpResponse<String> res = pair.request()
+      .path("reply")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("default");
+  }
+
+  @Test
+  void strictEncoding_encodedPercent_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=100%2520")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("100%20");
+  }
+
+  @Test
+  void strictEncoding_encodedEquals_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=1%2B1=2")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void noSetValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("");
+  }
+
+  @Test
+  void unboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?=value")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("default");
+  }
+
+  @Test
+  void strictEncoding_afterUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?=value&message=1%2B1=2")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_beforeUnboundValue_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=1%2B1=2&=value")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("1+1=2");
+  }
+
+  @Test
+  void strictEncoding_lowerHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%2a")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_upperHex_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%2A")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("*");
+  }
+
+  @Test
+  void strictEncoding_emoji_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%F0%9F%9A%80")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("\uD83D\uDE80"); // 🚀
+  }
+
+  @Test
+  void strictEncoding_truncatedBytes_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=%F0%9F")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("�");
+  }
+
+  @Test
+  void strictEncoding_nullByte_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply?message=config.json%00.txt")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("config.json\0.txt");
+  }
+
+  @Test
+  void strictEncoding_repeatedInput_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("reply-all?messages=this&messages=is&messages=repeated")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.body()).isEqualTo("[this, is, repeated]");
+  }
+
+  @Test
+  void strictEncoding_lonePlus_roundTripsCorrectly() {
+    final HttpResponse<String> res = pair.request()
+      // Use "path" to bypass encoding
+      .path("plus/+?plus=+")
+      .GET()
+      .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    // The first "+" comes from the path
+    //    because it should be an unmodified RFC 3986 parse
+    // The second " " comes from the query params
+    //    because the query params are subject to `application/x-www-form-urlencoded`
+    assertThat(res.body()).isEqualTo("+ ");
+  }
 }

--- a/avaje-jex/src/test/java/io/avaje/jex/routes/DPathParserTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/routes/DPathParserTest.java
@@ -11,12 +11,12 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-class PathParserTest {
+class DPathParserTest {
 
   @Test
   void matches_trailingSlash_honor() {
 
-    var pathParser = new PathParser("/one/{id}/", false);
+    var pathParser = new DPathParser("/one/{id}/", false);
     assertThat(pathParser.segmentCount()).isEqualTo(3);
 
     assertTrue(pathParser.matches("/one/1/"));
@@ -30,7 +30,7 @@ class PathParserTest {
   @Test
   void matches_trailingSlash_ignore() {
 
-    var pathParser = new PathParser("/one/{id}///", true);
+    var pathParser = new DPathParser("/one/{id}///", true);
     assertTrue(pathParser.matches("/one/1"));
     assertTrue(pathParser.matches("/one/2"));
     assertTrue(pathParser.matches("/one/2/"));
@@ -40,7 +40,7 @@ class PathParserTest {
   @Test
   void matches_litArg() {
 
-    var pathParser = new PathParser("/one/{id}", true);
+    var pathParser = new DPathParser("/one/{id}", true);
     assertTrue(pathParser.matches("/one/1"));
     assertTrue(pathParser.matches("/one/2"));
     assertThat(pathParser.segmentCount()).isEqualTo(2);
@@ -56,7 +56,7 @@ class PathParserTest {
   @Test
   void matches_argArgArg() {
 
-    final PathParser pathParser = new PathParser("/{a}/{b}/{c}", true);
+    final DPathParser pathParser = new DPathParser("/{a}/{b}/{c}", true);
     assertTrue(pathParser.matches("/1a/2b/3c"));
     assertThat(pathParser.segmentCount()).isEqualTo(3);
     assertThat(pathParser.raw()).isEqualTo("/{a}/{b}/{c}");
@@ -72,7 +72,7 @@ class PathParserTest {
   @Test
   void matches_litArgArgArg() {
 
-    final PathParser pathParser = new PathParser("/one/{a}/{b}/{c}", true);
+    final DPathParser pathParser = new DPathParser("/one/{a}/{b}/{c}", true);
     assertThat(pathParser.segmentCount()).isEqualTo(4);
     assertTrue(pathParser.matches("/one/1a/2b/3c"));
     assertTrue(pathParser.matches("/one/foo/bar/baz"));
@@ -88,13 +88,13 @@ class PathParserTest {
   @Test
   void illegalPath_adjacentViolation() {
     asList("/one/*<a>/after", "*{", "}*", "*<", ">*")
-      .forEach(path -> assertThrows(IllegalArgumentException.class, () -> new PathParser(path, true)));
+      .forEach(path -> assertThrows(IllegalArgumentException.class, () -> new DPathParser(path, true)));
   }
 
   @Test
   void matches_withSlashAccepting() {
 
-    final PathParser pathParser = new PathParser("/one/<a>/after", true);
+    final DPathParser pathParser = new DPathParser("/one/<a>/after", true);
     assertThat(pathParser.segmentCount()).isEqualTo(3);
     assertTrue(pathParser.matches("/one/bazz/after"));
     assertTrue(pathParser.matches("/one/foo/bar/after"));
@@ -111,7 +111,7 @@ class PathParserTest {
   @Test
   void matches_litArgLitArgArgLit() {
 
-    final PathParser pathParser = new PathParser("/one/{a}/two/{b}/{c}/end", true);
+    final DPathParser pathParser = new DPathParser("/one/{a}/two/{b}/{c}/end", true);
     assertThat(pathParser.segmentCount()).isEqualTo(6);
     assertTrue(pathParser.matches("/one/1a/two/2b/3c/end"));
     assertFalse(pathParser.matches("/on/1a/two/2b/3c/end"));
@@ -130,7 +130,7 @@ class PathParserTest {
   @Test
   void matches_litLit() {
 
-    final PathParser pathParser = new PathParser("/one/two", true);
+    final DPathParser pathParser = new DPathParser("/one/two", true);
     assertTrue(pathParser.matches("/one/two"));
     assertTrue(pathParser.matches("/one/two/"));
 
@@ -143,7 +143,7 @@ class PathParserTest {
   @Test
   void matches_litLit_honorTrailingSlash() {
     // ignoreTrailingSlashes=false: trailing slash must NOT match
-    final PathParser pathParser = new PathParser("/one/two", false);
+    final DPathParser pathParser = new DPathParser("/one/two", false);
     assertTrue(pathParser.literal());
 
     assertTrue(pathParser.matches("/one/two"));
@@ -155,7 +155,7 @@ class PathParserTest {
 
   @Test
   void matches_litLitLit_honorTrailingSlash() {
-    final PathParser pathParser = new PathParser("/a/b/c", false);
+    final DPathParser pathParser = new DPathParser("/a/b/c", false);
     assertTrue(pathParser.literal());
 
     assertTrue(pathParser.matches("/a/b/c"));
@@ -166,7 +166,7 @@ class PathParserTest {
 
   @Test
   void matches_before_litPrefix() {
-    final PathParser pathParser = new PathParser("/one/*", true);
+    final DPathParser pathParser = new DPathParser("/one/*", true);
     assertTrue(pathParser.matches("/one/two"));
     assertTrue(pathParser.matches("/one/two/three"));
     assertTrue(pathParser.matches("/one/two/three/four"));
@@ -174,7 +174,7 @@ class PathParserTest {
 
   @Test
   void matches_before_litPrefixAndSuffix() {
-    final PathParser pathParser = new PathParser("/one/*/three", true);
+    final DPathParser pathParser = new DPathParser("/one/*/three", true);
     assertTrue(pathParser.matches("/one/two/three"));
     assertTrue(pathParser.matches("/one/foo/three"));
 
@@ -184,7 +184,7 @@ class PathParserTest {
 
   @Test
   void matches_before_litPrefixAndSuffixAndWild() {
-    final PathParser pathParser = new PathParser("/one/*/three/*", true);
+    final DPathParser pathParser = new DPathParser("/one/*/three/*", true);
     assertTrue(pathParser.matches("/one/99/three/1000"));
     assertTrue(pathParser.matches("/one/99/three/1000/banana"));
     assertTrue(pathParser.matches("/one/two/three/four"));
@@ -197,7 +197,7 @@ class PathParserTest {
   @Test
   void withRegex() {
 
-    final PathParser pathParser = new PathParser("/{id:[0-9]+}", true);
+    final DPathParser pathParser = new DPathParser("/{id:[0-9]+}", true);
     assertTrue(pathParser.matches("/1"));
     assertTrue(pathParser.matches("/99"));
 
@@ -208,7 +208,7 @@ class PathParserTest {
   @Test
   void withRegex_andPrefix() {
 
-    final PathParser pathParser = new PathParser("/one/{id:[0-9]+}", true);
+    final DPathParser pathParser = new DPathParser("/one/{id:[0-9]+}", true);
     assertTrue(pathParser.matches("/one/1"));
     assertTrue(pathParser.matches("/one/99"));
 
@@ -219,7 +219,7 @@ class PathParserTest {
   @Test
   void withRegexWithLength() {
 
-    final PathParser pathParser = new PathParser("/{id:[0-9]{4}}", true);
+    final DPathParser pathParser = new DPathParser("/{id:[0-9]{4}}", true);
     assertTrue(pathParser.matches("/1234"));
     assertTrue(pathParser.matches("/9987"));
 
@@ -233,28 +233,28 @@ class PathParserTest {
 
   @Test
   void withColonLiteral() {
-    final PathParser pathParser = new PathParser("/path/my:action", true);
+    final DPathParser pathParser = new DPathParser("/path/my:action", true);
     assertThat(pathParser.segmentCount()).isEqualTo(2);
     assertThat(pathParser.literal()).isTrue();
   }
 
   @Test
   void withColonLiteral2() {
-    final PathParser pathParser = new PathParser("/path/to/my:action", true);
+    final DPathParser pathParser = new DPathParser("/path/to/my:action", true);
     assertThat(pathParser.segmentCount()).isEqualTo(3);
     assertThat(pathParser.literal()).isTrue();
   }
 
   @Test
   void withColonLiteral3() {
-    final PathParser pathParser = new PathParser("/path/my::action", true);
+    final DPathParser pathParser = new DPathParser("/path/my::action", true);
     assertThat(pathParser.segmentCount()).isEqualTo(2);
     assertThat(pathParser.literal()).isTrue();
   }
 
   @Test
   void withColonLiteral4() {
-    final PathParser pathParser = new PathParser("/path/my::action:again", true);
+    final DPathParser pathParser = new DPathParser("/path/my::action:again", true);
     assertThat(pathParser.segmentCount()).isEqualTo(2);
     assertThat(pathParser.literal()).isTrue();
   }
@@ -262,7 +262,7 @@ class PathParserTest {
   @Test
   void matches_splat0() {
 
-    final PathParser pathParser = new PathParser("/{a}/*", true);
+    final DPathParser pathParser = new DPathParser("/{a}/*", true);
     assertTrue(pathParser.matches("/1a/2b/3c"));
     assertThat(pathParser.segmentCount()).isEqualTo(2);
     assertThat(pathParser.raw()).isEqualTo("/{a}/*");
@@ -276,7 +276,7 @@ class PathParserTest {
   @Test
   void matches_splat0LiteralSplat() {
 
-    final PathParser pathParser = new PathParser("/{a}/*/and/*", true);
+    final DPathParser pathParser = new DPathParser("/{a}/*/and/*", true);
     assertThat(pathParser.raw()).isEqualTo("/{a}/*/and/*");
     assertThat(pathParser.segmentCount()).isEqualTo(4);
 
@@ -295,7 +295,7 @@ class PathParserTest {
 
   @Test
   void matches_slashConsumers() {
-    final PathParser pathParser = new PathParser("/{a}/<one>/and/<two>", true);
+    final DPathParser pathParser = new DPathParser("/{a}/<one>/and/<two>", true);
     assertThat(pathParser.raw()).isEqualTo("/{a}/<one>/and/<two>");
     assertThat(pathParser.segmentCount()).isEqualTo(4);
 
@@ -317,7 +317,7 @@ class PathParserTest {
 
   @Test
   void multiSegment_noSlashes() {
-    final PathParser pathParser = new PathParser("/x{a}y{b}z", true);
+    final DPathParser pathParser = new DPathParser("/x{a}y{b}z", true);
     assertThat(pathParser.raw()).isEqualTo("/x{a}y{b}z");
     assertThat(pathParser.segmentCount()).isEqualTo(1);
 
@@ -337,7 +337,7 @@ class PathParserTest {
 
   @Test
   void multiSegment_mixed() {
-    final PathParser pathParser = new PathParser("/{one}/x{two}y{three}z/{four}", true);
+    final DPathParser pathParser = new DPathParser("/{one}/x{two}y{three}z/{four}", true);
     assertThat(pathParser.segmentCount()).isEqualTo(3);
     assertFalse(pathParser.multiSlash());
 
@@ -353,7 +353,7 @@ class PathParserTest {
 
   @Test
   void multiSegment_mixed_slashConsuming() {
-    final PathParser pathParser = new PathParser("/<one>/x<two>y<three>z/<four>", true);
+    final DPathParser pathParser = new DPathParser("/<one>/x<two>y<three>z/<four>", true);
     assertThat(pathParser.segmentCount()).isEqualTo(3);
     assertTrue(pathParser.multiSlash());
 
@@ -387,6 +387,6 @@ class PathParserTest {
   }
 
   private ThrowableAssertAlternative<IllegalArgumentException> expectParseError(String path) {
-    return assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new PathParser(path, true));
+    return assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> new DPathParser(path, true));
   }
 }

--- a/avaje-jex/src/test/java/io/avaje/jex/routes/RouteIndexTest.java
+++ b/avaje-jex/src/test/java/io/avaje/jex/routes/RouteIndexTest.java
@@ -81,7 +81,7 @@ class RouteIndexTest {
   }
 
   private SpiRoutes.Entry entry(String path) {
-    return new RouteEntry(new PathParser(path, true), null, Set.of());
+    return new RouteEntry(new DPathParser(path, true), null, Set.of());
   }
 
 }


### PR DESCRIPTION
Builds off of #416, in that it allows for making the query, form, and param parsing configurable. The "default" is the  I stated in [this comment on that PR](https://github.com/avaje/avaje-jex/pull/416#issuecomment-4873116460), has an easy "switch" to get back to the current behaviour, and allows for you to do something else completely if you want.

Currently an RFC because:

1. I don't have tests written
2. I'm kinda "jumping the gun" a little, given Rob said we should agree on what "compliant and consistent" behaviour is before discussing options (sorry!)
3. I've referenced "pre-4.0" and "4.0", because changing the default behaviour to me would be a major version bump