### PR TITLE
`LongAdder` instead of `AtomicLong`

### DIFF
--- a/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/JdkContext.java
@@ -61,6 +61,7 @@ final class JdkContext implements Context {
   private Map<String, String> cookieMap;
   private int statusCode;
   private byte[] bodyBytes;
+  private long contentLength = Long.MIN_VALUE;
 
   private Charset characterEncoding;
   private OutputStream os;
@@ -170,8 +171,11 @@ final class JdkContext implements Context {
 
   @Override
   public long contentLength() {
-    final String len = header(Constants.CONTENT_LENGTH);
-    return len == null ? -1 : Long.parseLong(len);
+    if (contentLength == Long.MIN_VALUE) {
+      final String len = header(Constants.CONTENT_LENGTH);
+      contentLength = len == null ? -1 : Long.parseLong(len);
+    }
+    return contentLength;
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/RouteEntry.java
@@ -2,14 +2,14 @@ package io.avaje.jex.routes;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 import io.avaje.jex.http.ExchangeHandler;
 import io.avaje.jex.security.Role;
 
 final class RouteEntry implements SpiRoutes.Entry {
 
-  private final AtomicLong active = new AtomicLong();
+  private final LongAdder active = new LongAdder();
   private final PathParser path;
   private final ExchangeHandler handler;
   private final Set<Role> roles;
@@ -28,17 +28,17 @@ final class RouteEntry implements SpiRoutes.Entry {
 
   @Override
   public void inc() {
-    active.incrementAndGet();
+    active.increment();
   }
 
   @Override
   public void dec() {
-    active.decrementAndGet();
+    active.decrement();
   }
 
   @Override
   public long activeRequests() {
-    return active.get();
+    return active.sum();
   }
 
   @Override

--- a/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/routes/Routes.java
@@ -3,7 +3,7 @@ package io.avaje.jex.routes;
 import java.lang.System.Logger.Level;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.LockSupport;
 
 import io.avaje.applog.AppLog;
@@ -24,7 +24,7 @@ final class Routes implements SpiRoutes {
    */
   private final List<HttpFilter> filters;
 
-  private final AtomicLong noRouteCounter = new AtomicLong();
+  private final LongAdder noRouteCounter = new LongAdder();
 
   Routes(EnumMap<Routing.Type, RouteIndex> typeMap, List<HttpFilter> filters) {
     this.typeMap = typeMap;
@@ -38,17 +38,17 @@ final class Routes implements SpiRoutes {
 
   @Override
   public void inc() {
-    noRouteCounter.incrementAndGet();
+    noRouteCounter.increment();
   }
 
   @Override
   public void dec() {
-    noRouteCounter.decrementAndGet();
+    noRouteCounter.decrement();
   }
 
   @Override
   public long activeRequests() {
-    long total = noRouteCounter.get();
+    long total = noRouteCounter.sum();
     for (RouteIndex value : typeMap.values()) {
       total += value.activeRequests();
     }


### PR DESCRIPTION
- use `LongAdder` instead of `AtomicLong` (more performant for highly concurrent endpoints)
- cache contentLength