### PR TITLE
Add Content Disposition support

### DIFF
--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/AbstractStaticHandler.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/AbstractStaticHandler.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import com.sun.net.httpserver.HttpExchange;
@@ -33,6 +34,7 @@ abstract sealed class AbstractStaticHandler implements ExchangeHandler
   protected final String urlPrefix;
   protected final Predicate<Context> skipFilePredicate;
   protected final Map<String, String> headers;
+  protected final BiFunction<Context, String, ContentDisposition> contentDisposition;
   protected final boolean precompress;
   protected final Map<String, CachedResource> compressedFiles = new ConcurrentHashMap<>();
   private static final FileNameMap MIME_MAP = URLConnection.getFileNameMap();
@@ -43,6 +45,7 @@ abstract sealed class AbstractStaticHandler implements ExchangeHandler
       Map<String, String> mimeTypes,
       Map<String, String> headers,
       Predicate<Context> skipFilePredicate,
+      BiFunction<Context, String, ContentDisposition> contentDisposition,
       boolean precompress,
       CompressionConfig compressionConfig) {
     this.compressionConfig = compressionConfig;
@@ -50,6 +53,7 @@ abstract sealed class AbstractStaticHandler implements ExchangeHandler
     this.urlPrefix = urlPrefix;
     this.skipFilePredicate = skipFilePredicate;
     this.headers = headers;
+    this.contentDisposition = contentDisposition;
     this.mimeTypes = mimeTypes;
     this.precompress = precompress;
   }
@@ -82,6 +86,22 @@ abstract sealed class AbstractStaticHandler implements ExchangeHandler
           String ext = getExt(lower);
           return mimeTypes.getOrDefault(ext, "application/octet-stream");
         });
+  }
+
+  /** Set the Content-Disposition header when one has been configured. */
+  protected void applyContentDisposition(Context ctx, String path) {
+    if (contentDisposition == null) {
+      return;
+    }
+    var disposition = contentDisposition.apply(ctx, fileName(path));
+    if (disposition != null) {
+      ctx.header(Constants.CONTENT_DISPOSITION, List.of(disposition.headerValue()));
+    }
+  }
+
+  private static String fileName(String path) {
+    int separator = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+    return separator < 0 ? path : path.substring(separator + 1);
   }
 
   protected boolean isCached(final String path) {
@@ -122,6 +142,7 @@ abstract sealed class AbstractStaticHandler implements ExchangeHandler
         return false;
       }
       ctx.headerMap(cached.headers());
+      applyContentDisposition(ctx, path);
       ctx.header(Constants.CONTENT_LENGTH, String.valueOf(bytes.length));
       if (isHead) {
         ctx.writeEmpty(200);
@@ -132,6 +153,7 @@ abstract sealed class AbstractStaticHandler implements ExchangeHandler
     }
 
     ctx.header(Constants.CONTENT_TYPE, cached.headers().get(Constants.CONTENT_TYPE));
+    applyContentDisposition(ctx, path);
     if (isHead) {
       writeHeadResponse(ctx, new ByteArrayInputStream(bytes));
       return true;

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/ContentDisposition.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/ContentDisposition.java
@@ -1,0 +1,171 @@
+package io.avaje.jex.staticcontent;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The {@code Content-Disposition} header sent with a static resource.
+ *
+ * <p>The filename is sanitized and encoded following RFC 6266 / RFC 5987. When the filename
+ * contains non ascii characters both a legacy safe {@code filename} and an {@code filename*}
+ * parameter are written.
+ *
+ * <pre>{@code
+ * StaticContent.ofFile("downloads")
+ *   .directoryIndex("index.html")
+ *   .contentDisposition((ctx, filename) -> ContentDisposition.attachment(filename))
+ *   .build();
+ *
+ * }</pre>
+ *
+ * @param type the disposition type
+ * @param filename the sanitized filename, or null when no filename is sent
+ */
+public record ContentDisposition(Type type, String filename) {
+
+  /** The disposition type. */
+  public enum Type {
+    /** The resource is displayed by the browser. */
+    INLINE("inline"),
+    /** The resource is downloaded and saved by the browser. */
+    ATTACHMENT("attachment");
+
+    private final String value;
+
+    Type(String value) {
+      this.value = value;
+    }
+
+    String value() {
+      return value;
+    }
+  }
+
+  private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+  /** Characters that need no percent encoding in a RFC 5987 ext-value. */
+  private static final String ATTR_CHARS = "!#$&+-.^_`|~";
+
+  private static final String FALLBACK_NAME = "download";
+
+  /** Names that cannot be used as a file name on windows. */
+  private static final Set<String> RESERVED_DEVICE_NAMES =
+      Set.of(
+          "CON", "PRN", "AUX", "NUL", "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6",
+          "COM7", "COM8", "COM9", "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7",
+          "LPT8", "LPT9");
+
+  public ContentDisposition {
+    Objects.requireNonNull(type, "type is required");
+    filename = filename == null ? null : sanitize(filename);
+  }
+
+  /** Return an {@code inline} disposition with the given filename. */
+  public static ContentDisposition inline(String filename) {
+    return new ContentDisposition(Type.INLINE, filename);
+  }
+
+  /** Return an {@code inline} disposition with no filename. */
+  public static ContentDisposition inline() {
+    return new ContentDisposition(Type.INLINE, null);
+  }
+
+  /** Return an {@code attachment} disposition with the given filename. */
+  public static ContentDisposition attachment(String filename) {
+    return new ContentDisposition(Type.ATTACHMENT, filename);
+  }
+
+  /** Return an {@code attachment} disposition with no filename. */
+  public static ContentDisposition attachment() {
+    return new ContentDisposition(Type.ATTACHMENT, null);
+  }
+
+  /** Return the {@code Content-Disposition} header value. */
+  public String headerValue() {
+    if (filename == null) {
+      return type.value();
+    }
+    var sb =
+        new StringBuilder(type.value())
+            .append("; filename=\"")
+            .append(quoted(filename))
+            .append('"');
+    if (!isAscii(filename)) {
+      sb.append("; filename*=UTF-8''").append(extValue(filename));
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Strip any path components, control characters and windows device names such that the value is
+   * safe to write into a header and safe for the client to save to disk.
+   */
+  private static String sanitize(String filename) {
+    int separator = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+    var basename = separator < 0 ? filename : filename.substring(separator + 1);
+
+    var sb = new StringBuilder(basename.length());
+    for (int i = 0; i < basename.length(); i++) {
+      char ch = basename.charAt(i);
+      // drops CR/LF header injection along with all other control characters
+      if (ch >= 0x20 && ch != 0x7f) {
+        sb.append(ch);
+      }
+    }
+    var name = sb.toString().strip();
+    if (name.isEmpty() || ".".equals(name) || "..".equals(name)) {
+      return FALLBACK_NAME;
+    }
+    return isReservedDeviceName(name) ? "_" + name : name;
+  }
+
+  private static boolean isReservedDeviceName(String name) {
+    int dot = name.indexOf('.');
+    var stem = dot < 0 ? name : name.substring(0, dot);
+    return RESERVED_DEVICE_NAMES.contains(stem.toUpperCase(Locale.ROOT));
+  }
+
+  /** Ascii only quoted-string content, non ascii characters replaced by an underscore. */
+  private static String quoted(String name) {
+    var sb = new StringBuilder(name.length());
+    for (int i = 0; i < name.length(); i++) {
+      char ch = name.charAt(i);
+      if (ch > 0x7e) {
+        sb.append('_');
+      } else if (ch == '"' || ch == '\\') {
+        sb.append('\\').append(ch);
+      } else {
+        sb.append(ch);
+      }
+    }
+    return sb.toString();
+  }
+
+  /** RFC 5987 percent encoded utf8 value. */
+  private static String extValue(String name) {
+    var sb = new StringBuilder(name.length() * 2);
+    for (byte b : name.getBytes(StandardCharsets.UTF_8)) {
+      int ch = b & 0xFF;
+      if (ch >= 'A' && ch <= 'Z'
+          || ch >= 'a' && ch <= 'z'
+          || ch >= '0' && ch <= '9'
+          || ATTR_CHARS.indexOf(ch) >= 0) {
+        sb.append((char) ch);
+      } else {
+        sb.append('%').append(HEX[ch >> 4]).append(HEX[ch & 0xF]);
+      }
+    }
+    return sb.toString();
+  }
+
+  private static boolean isAscii(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (name.charAt(i) > 0x7e) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticClassResourceHandler.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticClassResourceHandler.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import io.avaje.jex.compression.CompressionConfig;
@@ -25,6 +26,7 @@ final class StaticClassResourceHandler extends AbstractStaticHandler {
       Map<String, String> mimeTypes,
       Map<String, String> headers,
       Predicate<Context> skipFilePredicate,
+      BiFunction<Context, String, ContentDisposition> contentDisposition,
       ClassResourceLoader resourceLoader,
       URL indexFile,
       URL spaRoot,
@@ -37,6 +39,7 @@ final class StaticClassResourceHandler extends AbstractStaticHandler {
         mimeTypes,
         headers,
         skipFilePredicate,
+        contentDisposition,
         precompress,
         compressionConfig);
 
@@ -99,6 +102,7 @@ final class StaticClassResourceHandler extends AbstractStaticHandler {
     try (var fis = path.openStream()) {
       ctx.header(CONTENT_TYPE, lookupMime(urlPath));
       ctx.headers(headers);
+      applyContentDisposition(ctx, urlPath);
       if (precompress) {
         addCachedEntry(ctx, urlPath, fis);
         return;

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticClassResourceHandler.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticClassResourceHandler.java
@@ -4,6 +4,7 @@ import static io.avaje.jex.core.Constants.*;
 
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -99,7 +100,14 @@ final class StaticClassResourceHandler extends AbstractStaticHandler {
   }
 
   private void sendURL(Context ctx, String urlPath, URL path) {
-    try (var fis = path.openStream()) {
+    final URLConnection connection;
+    try {
+      connection = path.openConnection();
+    } catch (final IOException e) {
+      throw404(ctx.exchange());
+      return;
+    }
+    try (var fis = connection.getInputStream()) {
       ctx.header(CONTENT_TYPE, lookupMime(urlPath));
       ctx.headers(headers);
       applyContentDisposition(ctx, urlPath);
@@ -113,7 +121,12 @@ final class StaticClassResourceHandler extends AbstractStaticHandler {
         return;
       }
 
-      ctx.rangedWrite(fis);
+      final long totalBytes = connection.getContentLengthLong();
+      if (totalBytes < 0) {
+        ctx.rangedWrite(fis);
+      } else {
+        ctx.rangedWrite(fis, totalBytes);
+      }
     } catch (final IOException e) {
       throw404(ctx.exchange());
     }

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticContent.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticContent.java
@@ -1,6 +1,7 @@
 package io.avaje.jex.staticcontent;
 
 import java.net.URLConnection;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import io.avaje.jex.http.Context;
@@ -10,22 +11,21 @@ import io.avaje.jex.spi.JexPlugin;
 
 /**
  * Static content resource handler.
+ *
  * <pre>{@code
+ * var staticContent = StaticContent.createFile("src/test/resources/public")
+ *    .directoryIndex("index.html")
+ *    .preCompress()
+ *    .build()
  *
- *  var staticContent = StaticContent.createFile("src/test/resources/public")
- *     .directoryIndex("index.html")
- *     .preCompress()
- *     .build()
- *
- *  Jex.create()
- *    .plugin(staticContent)
- *    .port(8080)
- *    .start();
+ * Jex.create()
+ *   .plugin(staticContent)
+ *   .port(8080)
+ *   .start();
  *
  * }</pre>
  */
-public sealed interface StaticContent extends JexPlugin
-  permits StaticResourceHandlerBuilder {
+public sealed interface StaticContent extends JexPlugin permits StaticResourceHandlerBuilder {
 
   /**
    * Create and return a new static content class path configuration.
@@ -37,8 +37,8 @@ public sealed interface StaticContent extends JexPlugin
   }
 
   /**
-   * Create and return a new static content class path configuration with the
-   * `/public` directory as the root.
+   * Create and return a new static content class path configuration with the `/public` directory as
+   * the root.
    */
   static Builder ofClassPath() {
     return StaticResourceHandlerBuilder.builder("/public/");
@@ -53,11 +53,8 @@ public sealed interface StaticContent extends JexPlugin
     return StaticResourceHandlerBuilder.builder(resourceRoot).file();
   }
 
-  /**
-   * Builder for StaticContent.
-   */
-  sealed interface Builder
-    permits StaticResourceHandlerBuilder {
+  /** Builder for StaticContent. */
+  sealed interface Builder permits StaticResourceHandlerBuilder {
 
     /**
      * Sets the HTTP route for the static resource handler.
@@ -77,7 +74,8 @@ public sealed interface StaticContent extends JexPlugin
     Builder directoryIndex(String directoryIndex);
 
     /**
-     * Redirects to index file when a static file cannot be found. This ensures the client side router handles the routing.
+     * Redirects to index file when a static file cannot be found. This ensures the client side
+     * router handles the routing.
      *
      * @param spaIndex the index file
      * @return the updated configuration
@@ -128,11 +126,50 @@ public sealed interface StaticContent extends JexPlugin
     /**
      * Adds a new response header to the configuration.
      *
-     * @param key   the header name
+     * @param key the header name
      * @param value the header value
      * @return the updated configuration
      */
     Builder putResponseHeader(String key, String value);
+
+    /**
+     * Sets the {@code Content-Disposition} type sent with every served resource, using the name of
+     * the served file as the filename.
+     *
+     * <pre>{@code
+     * StaticContent.ofFile("downloads")
+     *   .directoryIndex("index.html")
+     *   .contentDisposition(ContentDisposition.Type.ATTACHMENT)
+     *   .build();
+     *
+     * }</pre>
+     *
+     * @param type the disposition type
+     * @return the updated configuration
+     */
+    default Builder contentDisposition(ContentDisposition.Type type) {
+      return contentDisposition((ctx, filename) -> new ContentDisposition(type, filename));
+    }
+
+    /**
+     * Sets a function used to build the {@code Content-Disposition} header for each served
+     * resource. The function is given the request context and the name of the served file, and may
+     * return {@code null} to send no header.
+     *
+     * <pre>{@code
+     * StaticContent.ofFile("downloads")
+     *   .directoryIndex("index.html")
+     *   .contentDisposition((ctx, filename) -> filename.endsWith(".pdf")
+     *     ? ContentDisposition.inline(filename)
+     *     : ContentDisposition.attachment(filename))
+     *   .build();
+     *
+     * }</pre>
+     *
+     * @param contentDisposition the function building the disposition
+     * @return the updated configuration
+     */
+    Builder contentDisposition(BiFunction<Context, String, ContentDisposition> contentDisposition);
 
     /**
      * Sets a predicate to filter files based on the request context.
@@ -142,9 +179,7 @@ public sealed interface StaticContent extends JexPlugin
      */
     Builder skipFilePredicate(Predicate<Context> skipFilePredicate);
 
-    /**
-     * Build and return the StaticContent.
-     */
+    /** Build and return the StaticContent. */
     StaticContent build();
   }
 }

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticFileHandler.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticFileHandler.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import com.sun.net.httpserver.HttpExchange;
@@ -26,6 +27,7 @@ final class StaticFileHandler extends AbstractStaticHandler {
       Map<String, String> mimeTypes,
       Map<String, String> headers,
       Predicate<Context> skipFilePredicate,
+      BiFunction<Context, String, ContentDisposition> contentDisposition,
       Path welcomeFile,
       Path spaRoot,
       Path singleFile, boolean precompress,
@@ -36,6 +38,7 @@ final class StaticFileHandler extends AbstractStaticHandler {
         mimeTypes,
         headers,
         skipFilePredicate,
+        contentDisposition,
         precompress,
         compressionConfig);
     this.indexFile = welcomeFile;
@@ -97,6 +100,7 @@ final class StaticFileHandler extends AbstractStaticHandler {
       String mimeType = lookupMime(urlPath);
       ctx.header(CONTENT_TYPE, mimeType);
       ctx.headers(headers);
+      applyContentDisposition(ctx, urlPath);
       if (precompress) {
         addCachedEntry(ctx, urlPath, fis);
         return;

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticFileHandler.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticFileHandler.java
@@ -111,7 +111,7 @@ final class StaticFileHandler extends AbstractStaticHandler {
         return;
       }
 
-      ctx.rangedWrite(fis);
+      ctx.rangedWrite(fis, Files.size(canonicalFile));
     } catch (NoSuchFileException e) {
       if (spaRoot != null) {
         final var path = spaRoot.toString();

--- a/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticResourceHandlerBuilder.java
+++ b/avaje-jex-static-content/src/main/java/io/avaje/jex/staticcontent/StaticResourceHandlerBuilder.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
 import io.avaje.jex.Jex;
@@ -33,6 +34,7 @@ final class StaticResourceHandlerBuilder implements StaticContent.Builder, Stati
   private final Map<String, String> mimeTypes = new HashMap<>();
   private final Map<String, String> headers = new HashMap<>();
   private Predicate<Context> skipFilePredicate = NO_OP_PREDICATE;
+  private BiFunction<Context, String, ContentDisposition> contentDisposition;
   private boolean isClasspath = true;
   private boolean precompress;
   private Role[] roles = {};
@@ -126,6 +128,13 @@ final class StaticResourceHandlerBuilder implements StaticContent.Builder, Stati
   }
 
   @Override
+  public StaticResourceHandlerBuilder contentDisposition(
+      BiFunction<Context, String, ContentDisposition> contentDisposition) {
+    this.contentDisposition = contentDisposition;
+    return this;
+  }
+
+  @Override
   public StaticResourceHandlerBuilder skipFilePredicate(Predicate<Context> skipFilePredicate) {
     this.skipFilePredicate = skipFilePredicate;
     return this;
@@ -185,6 +194,7 @@ final class StaticResourceHandlerBuilder implements StaticContent.Builder, Stati
         mimeTypes,
         headers,
         skipFilePredicate,
+        contentDisposition,
         dirIndex,
         spaRootFile,
         singleFile,
@@ -212,6 +222,7 @@ final class StaticResourceHandlerBuilder implements StaticContent.Builder, Stati
         mimeTypes,
         headers,
         skipFilePredicate,
+        contentDisposition,
         resourceLoader,
         dirIndex,
         spaRootUrl,

--- a/avaje-jex-static-content/src/test/java/io/avaje/jex/staticcontent/ContentDispositionTest.java
+++ b/avaje-jex-static-content/src/test/java/io/avaje/jex/staticcontent/ContentDispositionTest.java
@@ -1,0 +1,58 @@
+package io.avaje.jex.staticcontent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ContentDispositionTest {
+
+  @Test
+  void noFilename() {
+    assertThat(ContentDisposition.attachment().headerValue()).isEqualTo("attachment");
+    assertThat(ContentDisposition.inline().headerValue()).isEqualTo("inline");
+  }
+
+  @Test
+  void asciiFilename() {
+    assertThat(ContentDisposition.attachment("report.pdf").headerValue())
+        .isEqualTo("attachment; filename=\"report.pdf\"");
+  }
+
+  @Test
+  void nonAsciiFilenameAddsExtValue() {
+    assertThat(ContentDisposition.inline("naïve café.txt").headerValue())
+        .isEqualTo("inline; filename=\"na_ve caf_.txt\"; filename*=UTF-8''na%C3%AFve%20caf%C3%A9.txt");
+  }
+
+  @Test
+  void stripsPathComponents() {
+    assertThat(ContentDisposition.attachment("/etc/passwd").filename()).isEqualTo("passwd");
+    assertThat(ContentDisposition.attachment("..\\..\\secret.txt").filename()).isEqualTo("secret.txt");
+  }
+
+  @Test
+  void stripsControlCharactersPreventingHeaderInjection() {
+    var disposition = ContentDisposition.attachment("evil\r\nX-Injected: yes.txt");
+    assertThat(disposition.filename()).isEqualTo("evilX-Injected: yes.txt");
+    assertThat(disposition.headerValue()).doesNotContain("\r").doesNotContain("\n");
+  }
+
+  @Test
+  void escapesQuotes() {
+    assertThat(ContentDisposition.attachment("we\"ird.txt").headerValue())
+        .isEqualTo("attachment; filename=\"we\\\"ird.txt\"");
+  }
+
+  @Test
+  void prefixesWindowsDeviceNames() {
+    assertThat(ContentDisposition.attachment("con.txt").filename()).isEqualTo("_con.txt");
+    assertThat(ContentDisposition.attachment("LPT1").filename()).isEqualTo("_LPT1");
+    assertThat(ContentDisposition.attachment("console.txt").filename()).isEqualTo("console.txt");
+  }
+
+  @Test
+  void emptyOrDotFilenameFallsBack() {
+    assertThat(ContentDisposition.attachment("   ").filename()).isEqualTo("download");
+    assertThat(ContentDisposition.attachment("..").filename()).isEqualTo("download");
+  }
+}

--- a/avaje-jex-static-content/src/test/java/io/avaje/jex/staticcontent/StaticContentDispositionTest.java
+++ b/avaje-jex-static-content/src/test/java/io/avaje/jex/staticcontent/StaticContentDispositionTest.java
@@ -1,0 +1,130 @@
+package io.avaje.jex.staticcontent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jex.Jex;
+import io.avaje.jex.test.TestPair;
+
+class StaticContentDispositionTest {
+
+  static TestPair pair = init();
+
+  static TestPair init() {
+    final Jex app =
+        Jex.create()
+            .plugin(
+                StaticContent.ofClassPath("/public")
+                    .directoryIndex("index.html")
+                    .route("/attach/*")
+                    .contentDisposition(ContentDisposition.Type.ATTACHMENT)
+                    .build())
+            .plugin(
+                StaticContent.ofFile("src/test/resources/public")
+                    .directoryIndex("index.html")
+                    .route("/attachFile/*")
+                    .contentDisposition(ContentDisposition.Type.ATTACHMENT)
+                    .build())
+            .plugin(
+                StaticContent.ofClassPath("/public")
+                    .directoryIndex("index.html")
+                    .route("/custom/*")
+                    .contentDisposition(
+                        (ctx, filename) ->
+                            filename.endsWith(".css")
+                                ? ContentDisposition.inline(filename)
+                                : null)
+                    .build())
+            .plugin(
+                StaticContent.ofClassPath("/public")
+                    .directoryIndex("index.html")
+                    .route("/cached/*")
+                    .preCompress()
+                    .contentDisposition(ContentDisposition.Type.ATTACHMENT)
+                    .build())
+            .plugin(
+                StaticContent.ofClassPath("/logback.xml")
+                    .route("/single")
+                    .contentDisposition(ContentDisposition.Type.ATTACHMENT)
+                    .build());
+
+    return TestPair.create(app);
+  }
+
+  @AfterAll
+  static void end() {
+    pair.shutdown();
+  }
+
+  private static String disposition(HttpResponse<String> res) {
+    return res.headers().firstValue("Content-Disposition").orElse(null);
+  }
+
+  @Test
+  void classPathAttachment() {
+    HttpResponse<String> res = pair.request().path("attach/sus.txt").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isEqualTo("attachment; filename=\"sus.txt\"");
+  }
+
+  @Test
+  void fileAttachment() {
+    HttpResponse<String> res = pair.request().path("attachFile/sus.txt").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isEqualTo("attachment; filename=\"sus.txt\"");
+  }
+
+  @Test
+  void directoryIndexAttachment() {
+    HttpResponse<String> res = pair.request().path("attach/").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isEqualTo("attachment; filename=\"index.html\"");
+  }
+
+  @Test
+  void singleFileAttachment() {
+    HttpResponse<String> res = pair.request().path("single").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isEqualTo("attachment; filename=\"logback.xml\"");
+  }
+
+  @Test
+  void filenameWithSpaceIsQuoted() {
+    HttpResponse<String> res =
+        pair.request().path("attach/Extinction%20Party.txt").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isEqualTo("attachment; filename=\"Extinction Party.txt\"");
+  }
+
+  @Test
+  void headRequestGetsDisposition() {
+    HttpResponse<String> res = pair.request().path("attach/sus.txt").HEAD().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isEqualTo("attachment; filename=\"sus.txt\"");
+  }
+
+  @Test
+  void nullDispositionSendsNoHeader() {
+    HttpResponse<String> res = pair.request().path("custom/sus.txt").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isNull();
+
+    res = pair.request().path("custom/bundle.css").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(disposition(res)).isEqualTo("inline; filename=\"bundle.css\"");
+  }
+
+  @Test
+  void preCompressedIsNotDuplicatedOnCacheHit() {
+    for (int i = 0; i < 3; i++) {
+      HttpResponse<String> res = pair.request().path("cached/bundle.css").GET().asString();
+      assertThat(res.statusCode()).isEqualTo(200);
+      assertThat(res.headers().allValues("Content-Disposition"))
+          .containsExactly("attachment; filename=\"bundle.css\"");
+    }
+  }
+}

--- a/avaje-jex-static-content/src/test/java/io/avaje/jex/staticcontent/StaticFileTest.java
+++ b/avaje-jex-static-content/src/test/java/io/avaje/jex/staticcontent/StaticFileTest.java
@@ -3,6 +3,7 @@ package io.avaje.jex.staticcontent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import org.junit.jupiter.api.AfterAll;
@@ -143,6 +144,34 @@ class StaticFileTest {
     HttpResponse<String> res = pair.request().path("indexWildFile/").GET().asString();
     assertThat(res.statusCode()).isEqualTo(200);
     assertThat(res.headers().firstValue("Content-Type").orElseThrow()).contains("html");
+  }
+
+  @Test
+  void contentLengthSetForFileLargerThanResponseBuffer() {
+    HttpResponse<String> res = pair.request().path("indexWildFile/bundle.css").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.headers().firstValue("Content-Length").orElseThrow())
+        .isEqualTo(String.valueOf(res.body().getBytes(StandardCharsets.UTF_8).length));
+  }
+
+  @Test
+  void contentLengthSetForClasspathResource() {
+    HttpResponse<String> res = pair.request().path("indexWild/bundle.css").GET().asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.headers().firstValue("Content-Length").orElseThrow())
+        .isEqualTo(String.valueOf(res.body().getBytes(StandardCharsets.UTF_8).length));
+  }
+
+  @Test
+  void compressionStillAppliedWhenContentLengthKnown() {
+    HttpResponse<String> res =
+        pair.request()
+            .path("indexWildFile/bundle.css")
+            .header("Accept-Encoding", "gzip")
+            .GET()
+            .asString();
+    assertThat(res.statusCode()).isEqualTo(200);
+    assertThat(res.headers().firstValue("Content-Encoding")).contains("gzip");
   }
 
   @Test

--- a/avaje-jex/src/main/java/io/avaje/jex/core/Constants.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/Constants.java
@@ -12,6 +12,7 @@ public final class Constants {
   public static final String HOST = "Host";
   public static final String USER_AGENT = "User-agent";
   public static final String ACCEPT_ENCODING = "Accept-encoding";
+  public static final String CONTENT_DISPOSITION = "Content-disposition";
 
   public static final String TEXT_HTML = "text/html";
   public static final String TEXT_PLAIN = "text/plain";

--- a/avaje-jex/src/main/java/io/avaje/jex/core/RangeWriter.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/RangeWriter.java
@@ -7,6 +7,7 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 
+import io.avaje.jex.compression.CompressionConfig;
 import io.avaje.jex.http.Context;
 import io.avaje.jex.http.HttpStatus;
 
@@ -14,11 +15,21 @@ final class RangeWriter {
 
   private static final int DEFAULT_BUFFER_SIZE = 16384;
 
-  static void write(Context ctx, InputStream inputStream, long totalBytes, long chunkSize) {
+  static void write(
+      Context ctx,
+      InputStream inputStream,
+      long totalBytes,
+      long chunkSize,
+      CompressionConfig compression) {
 
     ctx.header(Constants.ACCEPT_RANGES, "bytes");
     final String rangeHeader = ctx.header(Constants.RANGE);
     if (rangeHeader == null) {
+      if (totalBytes >= 0
+          && ctx.responseHeader(Constants.CONTENT_LENGTH) == null
+          && !maybeCompressed(ctx, compression)) {
+        ctx.contentLength(totalBytes);
+      }
       ctx.write(inputStream);
       return;
     }
@@ -70,6 +81,15 @@ final class RangeWriter {
       outputStream.write(buffer, 0, read);
       bytesLeft -= read;
     }
+  }
+
+  /** Return true unless we can be sure the body is written uncompressed. */
+  private static boolean maybeCompressed(Context ctx, CompressionConfig compression) {
+    return compression.compressionEnabled()
+        && compression.allowsForCompression(ctx.responseHeader(Constants.CONTENT_TYPE))
+        && compression
+            .findMatchingCompressor(ctx.headerValues(Constants.ACCEPT_ENCODING))
+            .isPresent();
   }
 
   private static boolean isAudioOrVideo(String contentType) {

--- a/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
+++ b/avaje-jex/src/main/java/io/avaje/jex/core/ServiceManager.java
@@ -110,7 +110,7 @@ final class ServiceManager {
   }
 
   void writeRange(Context ctx, InputStream is, long totalBytes) {
-    RangeWriter.write(ctx, is, totalBytes, rangeChunks);
+    RangeWriter.write(ctx, is, totalBytes, rangeChunks, compressionConfig);
   }
 
   void maybeClose(Object iterator) {


### PR DESCRIPTION
I saw https://github.com/javalin/javalin/issues/2639 and decided to implement for us.

- Adds a new config option to set the Content-Disposition header
- Handle files bigger than 2GB not sending correct content length (`Inputstream#available` was capped to `Integer.MAX_VALUE` and would truncate)
- RangeWriter non-ranged branch now sets Content-Length from the known size (if not compressable)