### PR TITLE
`http2-robaho`

### DIFF
--- a/avaje-jex-http2-robaho/pom.xml
+++ b/avaje-jex-http2-robaho/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.avaje</groupId>
+    <artifactId>avaje-jex-parent</artifactId>
+    <version>3.4-RC2</version>
+  </parent>
+  <name>avaje-jex-http2-robaho</name>
+  <artifactId>avaje-jex-http2-robaho</artifactId>
+  <version>0.1</version>
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <robaho.version>1.0.29</robaho.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>io.github.robaho</groupId>
+      <artifactId>httpserver</artifactId>
+      <version>${robaho.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jex-ssl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jex-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb-generator</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/avaje-jex-http2-robaho/src/main/java/io/avaje/jex/http2/robaho/RobahoHttp2JexPlugin.java
+++ b/avaje-jex-http2-robaho/src/main/java/io/avaje/jex/http2/robaho/RobahoHttp2JexPlugin.java
@@ -1,0 +1,27 @@
+package io.avaje.jex.http2.robaho;
+
+import io.avaje.jex.Jex;
+import io.avaje.jex.spi.JexPlugin;
+import robaho.net.httpserver.DefaultHttpServerProvider;
+
+/** A plugin that configures Jex to enable HTTP/2 using Jetty. */
+public final class RobahoHttp2JexPlugin implements JexPlugin {
+
+  private RobahoHttp2JexPlugin() {}
+
+  /**
+   * Creates a new instance of the {@code RobahoHttp2JexPlugin}.
+   *
+   * @return The new plugin instance.
+   */
+  public static RobahoHttp2JexPlugin create() {
+    return new RobahoHttp2JexPlugin();
+  }
+
+  @Override
+  public void apply(Jex jex) {
+    System.setProperty("robaho.net.httpserver.http2OverSSL", "true");
+    jex.config()
+        .serverProvider(new DefaultHttpServerProvider());
+  }
+}

--- a/avaje-jex-http2-robaho/src/main/java/module-info.java
+++ b/avaje-jex-http2-robaho/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module io.avaje.jex.http2.robaho {
+  requires transitive io.avaje.jex.ssl;
+  requires java.base;
+  requires robaho.httpserver;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <module>avaje-jex-ssl</module>
     <module>avaje-jex-websockets</module>
     <!-- <module>avaje-jex-http3-flupke</module>
+    <module>avaje-jex-http2-robaho</module>
     <module>avaje-jex-grizzly-spi</module> -->
   </modules>
 


### PR DESCRIPTION
If it still serves a purpose / isn't stale. 

Related-to: https://github.com/avaje/avaje-jex/pull/331
Signed-off-by: Mahied Maruf contact@mechite.com